### PR TITLE
chore: update gas cost for devnet 4

### DIFF
--- a/crates/eip7702/src/constants.rs
+++ b/crates/eip7702/src/constants.rs
@@ -15,7 +15,7 @@ pub const MAGIC: u8 = 0x05;
 /// An additional gas cost per EIP7702 authorization list item.
 ///
 /// See also [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702).
-pub const PER_AUTH_BASE_COST: u64 = 2500;
+pub const PER_AUTH_BASE_COST: u64 = 12500;
 
 /// A gas refund for EIP7702 transactions if the authority account already exists in the trie.
 ///


### PR DESCRIPTION

## Motivation

The `PER_AUTH_BASE_COST` was bumped to 12500 in devnet 4. See https://github.com/ethereum/EIPs/blob/a7fb2260ae2ea39bdd31886832c9e45452d0e76a/EIPS/eip-7702.md

## Solution

Change the gas cost.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
