### PR TITLE
fix: rm dep on alloy-serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 [workspace.dependencies]
 alloy-primitives = { version = "0.8.0", default-features = false }
 alloy-rlp = { version = "0.3", default-features = false }
-alloy-serde = { version = "0.3", default-features = false }
 
 # serde
 serde = { version = "1.0", default-features = false, features = [

--- a/crates/eip7702/Cargo.toml
+++ b/crates/eip7702/Cargo.toml
@@ -20,7 +20,6 @@ workspace = true
 [dependencies]
 alloy-primitives = { workspace = true, features = ["rlp"] }
 alloy-rlp = { workspace = true, features = ["derive"] }
-alloy-serde = { workspace = true, optional = true }
 
 # serde
 serde = { workspace = true, optional = true }
@@ -41,7 +40,7 @@ serde_json.workspace = true
 [features]
 default = ["std"]
 std = ["alloy-primitives/std", "alloy-rlp/std", "serde?/std"]
-serde = ["dep:serde", "dep:alloy-serde", "alloy-primitives/serde"]
+serde = ["dep:serde", "alloy-primitives/serde"]
 serde-bincode-compat = ["serde_with"]
 arbitrary = ["std", "dep:arbitrary", "dep:rand", "alloy-primitives/arbitrary"]
 k256 = ["alloy-primitives/k256", "dep:k256"]

--- a/crates/eip7702/src/auth_list.rs
+++ b/crates/eip7702/src/auth_list.rs
@@ -47,7 +47,7 @@ impl RecoveredAuthority {
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Authorization {
     /// The chain ID of the authorization.
-    #[cfg_attr(feature = "serde", serde(with = "alloy_serde::quantity"))]
+    #[cfg_attr(feature = "serde", serde(with = "quantity"))]
     pub chain_id: u64,
     /// The address of the authorization.
     pub address: Address,


### PR DESCRIPTION

## Motivation

Issues with bumping `alloy-serde` if `alloy-eips` depends on it

## Solution

Use duplicated quantity encoder

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
