### PR TITLE
fix: deserialize into an empty access list on `null`

### DIFF
--- a/crates/eip2930/src/lib.rs
+++ b/crates/eip2930/src/lib.rs
@@ -209,8 +209,14 @@ mod tests {
 
     #[test]
     fn access_list_de_null() {
-        let null_list_str = "null";
-        let list = serde_json::from_str::<AccessList>(null_list_str).unwrap();
+        let non_null_str = "a non-null value";
+        assert!(serde_json::from_str::<AccessList>(non_null_str).is_err());
+
+        let malformed_array = r#"["some malformed array"]"#;
+        assert!(serde_json::from_str::<AccessList>(malformed_array).is_err());
+
+        let null_str = "null";
+        let list = serde_json::from_str::<AccessList>(null_str).unwrap();
         assert_eq!(list, AccessList::default());
     }
 

--- a/crates/eip2930/src/lib.rs
+++ b/crates/eip2930/src/lib.rs
@@ -35,8 +35,10 @@ impl AccessListItem {
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, RlpDecodableWrapper, RlpEncodableWrapper)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(default))]
-pub struct AccessList(pub Vec<AccessListItem>);
+pub struct AccessList(
+    #[cfg_attr(feature = "serde", serde(deserialize_with = "deserialize_null_or_empty"))]
+    pub  Vec<AccessListItem>,
+);
 
 impl From<Vec<AccessListItem>> for AccessList {
     fn from(list: Vec<AccessListItem>) -> Self {
@@ -178,6 +180,16 @@ impl AccessListResult {
     pub const fn is_err(&self) -> bool {
         self.error.is_some()
     }
+}
+
+#[cfg(feature = "serde")]
+fn deserialize_null_or_empty<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    use serde::Deserialize;
+    Ok(Option::<Vec<T>>::deserialize(deserializer)?.unwrap_or_default())
 }
 
 #[cfg(all(test, feature = "serde"))]

--- a/crates/eip2930/src/lib.rs
+++ b/crates/eip2930/src/lib.rs
@@ -208,6 +208,13 @@ mod tests {
     }
 
     #[test]
+    fn access_list_de_null() {
+        let null_list_str = "null";
+        let list = serde_json::from_str::<AccessList>(null_list_str).unwrap();
+        assert_eq!(list, AccessList::default());
+    }
+
+    #[test]
     fn access_list_with_gas_used() {
         let list = AccessListResult {
             access_list: AccessList(vec![

--- a/crates/eip2930/src/lib.rs
+++ b/crates/eip2930/src/lib.rs
@@ -35,6 +35,7 @@ impl AccessListItem {
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, RlpDecodableWrapper, RlpEncodableWrapper)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct AccessList(pub Vec<AccessListItem>);
 
 impl From<Vec<AccessListItem>> for AccessList {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Under some conditions, Filecoin RPC providers returns the details of EIP-1559 transactions with the `accessList` attribute set to `null` instead of an empty array (see https://github.com/filecoin-project/lotus/issues/12214).

Example of such a transaction:
```bash
> curl -X POST \
  -H "Content-Type: application/json" \
  --data '{
    "jsonrpc":"2.0",
    "method":"eth_getTransactionByHash",
    "params":["0x96ca611648da9a1cb430a9124491b97bbd6fc0e0d8851b1a6fb261fdd128b1c8"],
    "id":1
  }' \                                     
  https://api.node.glif.io/rpc/v1 | jq

{
  "id": 1,
  "jsonrpc": "2.0",
  "result": {
    "chainId": "0x13a",
    "nonce": "0xc94",
    "hash": "0x96ca611648da9a1cb430a9124491b97bbd6fc0e0d8851b1a6fb261fdd128b1c8",
    "blockHash": "0x5a1b8e9b7788cc96cf7c52cd66dd57120893313426a484219fff288e0a84e7df",
    "blockNumber": "0x4bbd62",
    "transactionIndex": "0x1c",
    "from": "0x4f122d7fce7971e38801af5d96fcd4ed83efd654",
    "to": "0xa2aa501b19aff244d90cc15a4cf739d2725b5729",
    "value": "0x1",
    "type": "0x2",
    "input": "0x[removed]",
    "gas": "0x478bcff",
    "maxFeePerGas": "0x29e564f",
    "maxPriorityFeePerGas": "0x1be7d",
    "accessList": null,
    "v": "0x1",
    "r": "0xe1400ceeafde652752b510333a765cf9b6bd36c212f71e8731d85b30395d080d",
    "s": "0x5a97f9e33012c31dd00f74f67ff9170e28811b7e8ae7e156c8ff9f5319346551"
  }
}
```

This causes a deserialization error when attempting to deserialize the transaction into a `TxEip1559` since `accessList` is malformed.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This PR adds the `deserialize_with` attribute to the vec inside `AccessList` to ensure that it deserializes into an empty vec in case of deserialization failure. 

If adding a dependency to `serde_with` is acceptable, I can switch to using `#[serde_as(as = "DefaultOnNull")]` instead of a manual implementation.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
