### PR TITLE
feat(eip2930,eip7702): Add Borsh support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ option-if-let-else = "warn"
 redundant-clone = "warn"
 
 [workspace.dependencies]
-alloy-primitives = { version = "1.0", default-features = false }
+alloy-primitives = { version = "1.4", default-features = false }
 alloy-rlp = { version = "0.3", default-features = false }
 
 # serde
@@ -38,6 +38,9 @@ serde = { version = "1.0", default-features = false, features = [
     "alloc",
 ] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+
+# borsh
+borsh = { version = "1.5", default-features = false }
 
 # arbitrary
 arbitrary = "1.3"

--- a/crates/eip2930/Cargo.toml
+++ b/crates/eip2930/Cargo.toml
@@ -28,6 +28,9 @@ alloy-rlp = { workspace = true, features = ["derive"] }
 # serde
 serde = { workspace = true, optional = true }
 
+# borsh
+borsh = { workspace = true, optional = true, features = ["derive"] }
+
 # arbitrary
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 rand = { workspace = true, optional = true }
@@ -40,3 +43,7 @@ default = ["std"]
 std = ["alloy-primitives/std", "alloy-rlp/std", "serde?/std"]
 serde = ["dep:serde", "alloy-primitives/serde"]
 arbitrary = ["std", "dep:arbitrary", "dep:rand", "alloy-primitives/arbitrary"]
+borsh = [
+	"dep:borsh",
+	"alloy-primitives/borsh",
+]

--- a/crates/eip2930/src/lib.rs
+++ b/crates/eip2930/src/lib.rs
@@ -16,6 +16,7 @@ use core::{mem, ops::Deref};
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
 pub struct AccessListItem {
     /// Account addresses that would be loaded at the start of execution
     pub address: Address,
@@ -35,6 +36,7 @@ impl AccessListItem {
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, RlpDecodableWrapper, RlpEncodableWrapper)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
 pub struct AccessList(pub Vec<AccessListItem>);
 
 impl From<Vec<AccessListItem>> for AccessList {
@@ -139,6 +141,7 @@ impl AccessList {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
 pub struct AccessListWithGasUsed {
     /// List with accounts accessed during transaction.
     pub access_list: AccessList,
@@ -150,6 +153,7 @@ pub struct AccessListWithGasUsed {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
 pub struct AccessListResult {
     /// List with accounts accessed during transaction.
     pub access_list: AccessList,

--- a/crates/eip7702/Cargo.toml
+++ b/crates/eip7702/Cargo.toml
@@ -31,6 +31,9 @@ serde_with = { version = "3", optional = true, default-features = false, feature
     "macros",
 ] }
 
+# borsh
+borsh = { workspace = true, optional = true, features = ["derive"] }
+
 # arbitrary
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 
@@ -53,3 +56,6 @@ serde = ["dep:serde", "alloy-primitives/serde"]
 serde-bincode-compat = ["serde_with"]
 arbitrary = ["std", "dep:arbitrary", "dep:rand", "alloy-primitives/arbitrary"]
 k256 = ["alloy-primitives/k256", "dep:k256"]
+borsh = [
+	"dep:borsh",
+]

--- a/crates/eip7702/src/auth_list.rs
+++ b/crates/eip7702/src/auth_list.rs
@@ -13,6 +13,7 @@ use core::hash::{Hash, Hasher};
 /// It can either be valid (containing an [`Address`]) or invalid (indicating recovery failure).
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
 pub enum RecoveredAuthority {
     /// Indicates a successfully recovered authority address.
     Valid(Address),
@@ -45,6 +46,7 @@ impl RecoveredAuthority {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
 pub struct Authorization {
     /// The chain ID of the authorization.
     pub chain_id: U256,
@@ -104,6 +106,7 @@ impl Authorization {
 /// A signed EIP-7702 authorization.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
 pub struct SignedAuthorization {
     /// Inner authorization.
     #[cfg_attr(feature = "serde", serde(flatten))]
@@ -326,6 +329,7 @@ impl<'de> serde::Deserialize<'de> for SignedAuthorization {
 /// A recovered authorization.
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
 pub struct RecoveredAuthorization {
     #[cfg_attr(feature = "serde", serde(flatten))]
     inner: Authorization,


### PR DESCRIPTION
## Motivation

Close #42 

## Solution

- Bump alloy-primitives to version 1.4
- Implement Borsh serialization/deserialization for relevant structs in eip2930 and eip7702

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
