### PR TITLE
fix(eip7928): add missing borsh derive to Bal, remove redundant cfg

### DIFF
--- a/crates/eip7928/src/account_changes.rs
+++ b/crates/eip7928/src/account_changes.rs
@@ -147,7 +147,6 @@ impl AccountChanges {
 }
 
 #[cfg(all(test, feature = "serde"))]
-#[cfg(test)]
 mod tests {
     use crate::StorageChange;
 

--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -58,6 +58,7 @@ pub mod bal {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "rlp", derive(alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable))]
     #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+    #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
     pub struct Bal(Vec<AccountChanges>);
 
     impl From<Bal> for Vec<AccountChanges> {

--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -194,9 +194,6 @@ pub mod bal {
         }
 
         /// Returns a summary of all change counts for metrics reporting.
-        ///
-        /// Returns a tuple of (account_changes, storage_changes, balance_changes, nonce_changes,
-        /// code_changes).
         pub fn change_counts(&self) -> BalChangeCounts {
             let mut counts = BalChangeCounts::default();
             for account in &self.0 {


### PR DESCRIPTION
Add missing `borsh` derive to the `Bal` wrapper struct and clean up a redundant `#[cfg(test)]` attribute.

**borsh derive on Bal**

All six component types in this crate (`StorageChange`, `SlotChanges`, `BalanceChange`, `NonceChange`, `CodeChange`, `AccountChanges`) and the analogous `AccessList` wrapper in eip2930 derive `BorshSerialize` + `BorshDeserialize` behind the `borsh` feature flag. `Bal` was the only type missing it, which breaks borsh round-tripping when users enable the feature.

**Redundant cfg removal**

The test module in `account_changes.rs` had:
`ust
#[cfg(all(test, feature = serde))]
#[cfg(test)]
mod tests {
`
The second `#[cfg(test)]` is redundant since the first attribute already requires `test`. Removed to match the pattern used in `eip2930/src/lib.rs` and `eip7702/src/auth_list.rs`.