### PR TITLE
fix(eip7928): add missing storage_reads to BalChangeCounts and fix stale doc

### DIFF
--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -193,9 +193,6 @@ pub mod bal {
         }
 
         /// Returns a summary of all change counts for metrics reporting.
-        ///
-        /// Returns a tuple of (account_changes, storage_changes, balance_changes, nonce_changes,
-        /// code_changes).
         pub fn change_counts(&self) -> BalChangeCounts {
             let mut counts = BalChangeCounts::default();
             for account in &self.0 {


### PR DESCRIPTION
## Motivation

`BalChangeCounts` is meant to provide a summary of all change counts in a BAL for metrics reporting. Every `AccountChanges` field has a corresponding counter in the struct except `storage_reads`, which is silently excluded even though it's a first-class field tracked by `total_storage_reads()`, `total_slots()`, and `total_bal_items()`.

The `change_counts()` doc also says 'Returns a tuple' when it actually returns a `BalChangeCounts` struct.

## Solution

- Add `storage_reads: usize` field to `BalChangeCounts`
- Count `storage_reads` in the `change_counts()` loop
- Remove the stale 'Returns a tuple' doc line
- Add test verifying `change_counts()` includes storage reads

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes