### PR TITLE
fix(eip2930): add is_ok() and RLP roundtrip tests; fix(eip7702): correct PER_EMPTY_ACCOUNT_COST doc

### DIFF
--- a/crates/eip2930/src/lib.rs
+++ b/crates/eip2930/src/lib.rs
@@ -181,12 +181,60 @@ impl AccessListResult {
     pub const fn is_err(&self) -> bool {
         self.error.is_some()
     }
+
+    /// Returns `true` if there is no error in the result.
+    #[inline]
+    pub const fn is_ok(&self) -> bool {
+        self.error.is_none()
+    }
 }
 
-#[cfg(all(test, feature = "serde"))]
+#[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
+    use alloy_rlp::{Decodable, Encodable};
 
+    #[test]
+    fn access_list_item_rlp_roundtrip() {
+        let item = AccessListItem {
+            address: Address::left_padding_from(&[1]),
+            storage_keys: vec![B256::with_last_byte(2)],
+        };
+        let mut buf = Vec::new();
+        item.encode(&mut buf);
+        let decoded = AccessListItem::decode(&mut buf.as_ref()).unwrap();
+        assert_eq!(buf.len(), item.length());
+        assert_eq!(decoded, item);
+    }
+
+    #[test]
+    fn access_list_rlp_roundtrip() {
+        let list = AccessList(vec![
+            AccessListItem {
+                address: Address::left_padding_from(&[1]),
+                storage_keys: vec![B256::with_last_byte(2), B256::with_last_byte(3)],
+            },
+            AccessListItem { address: Address::left_padding_from(&[4]), storage_keys: vec![] },
+        ]);
+        let mut buf = Vec::new();
+        list.encode(&mut buf);
+        let decoded = AccessList::decode(&mut buf.as_ref()).unwrap();
+        assert_eq!(buf.len(), list.length());
+        assert_eq!(decoded, list);
+    }
+
+    #[test]
+    fn empty_access_list_rlp_roundtrip() {
+        let list = AccessList::default();
+        let mut buf = Vec::new();
+        list.encode(&mut buf);
+        let decoded = AccessList::decode(&mut buf.as_ref()).unwrap();
+        assert_eq!(buf.len(), list.length());
+        assert_eq!(decoded, list);
+    }
+
+    #[cfg(feature = "serde")]
     #[test]
     fn access_list_serde() {
         let list = AccessList(vec![
@@ -198,6 +246,7 @@ mod tests {
         assert_eq!(list, list2);
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn access_list_with_gas_used() {
         let list = AccessListResult {

--- a/crates/eip7702/src/constants.rs
+++ b/crates/eip7702/src/constants.rs
@@ -18,9 +18,10 @@ pub const MAGIC: u8 = 0x05;
 /// See also [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702).
 pub const PER_AUTH_BASE_COST: u64 = 12500;
 
-/// A gas refund for EIP7702 transactions if the authority account already exists in the trie.
+/// The gas cost charged per authorization list item for EIP-7702 transactions.
 ///
-/// The refund is `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST`.
+/// If the authority account already exists in the trie,
+/// `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST` is added to the global refund counter.
 ///
 /// See also [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702).
 pub const PER_EMPTY_ACCOUNT_COST: u64 = 25000;


### PR DESCRIPTION
## Motivation

`AccessListResult` has `is_err()` and `ensure_ok()` but no `is_ok()`, which forces callers into `!result.is_err()` for the positive case. Other types in this repo (e.g. `RecoveredAuthority` with `is_valid()`/`is_invalid()`) provide both directions.

`AccessListItem` and `AccessList` derive `RlpEncodable`/`RlpDecodable` but have zero RLP tests. Every other EIP crate in this repo tests its RLP impls (eip7702's `test_encode_decode_auth`, eip2124's `forkid_serialization`). Since RLP is the wire encoding format for access lists in EIP-2930 transactions, this should be covered.

The `PER_EMPTY_ACCOUNT_COST` doc in eip7702 described the constant as a gas refund, but per the EIP-7702 spec it's the intrinsic gas cost per authorization list item. The refund is `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST`, granted when the authority already exists. revm documents the same constant correctly as a cost.

## Solution

**eip2930:**
- Added `is_ok()` to `AccessListResult`, the complement of `is_err()`
- Changed the test module gate from `#[cfg(all(test, feature = "serde"))]` to `#[cfg(test)]`, gating individual serde tests with `#[cfg(feature = "serde")]` instead (matches eip7702 pattern)
- Added three RLP roundtrip tests: `access_list_item_rlp_roundtrip`, `access_list_rlp_roundtrip`, `empty_access_list_rlp_roundtrip`

**eip7702:**
- Corrected `PER_EMPTY_ACCOUNT_COST` doc to describe it as a cost, with the refund behavior explained in context

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
