### PR TITLE
chore: add helper struct DecodedBal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ redundant-clone = "warn"
 [workspace.dependencies]
 alloy-primitives = { version = "1.4", default-features = false }
 alloy-rlp = { version = "0.3", default-features = false }
+once_cell = { version = "1.20", default-features = false, features = ["critical-section"] }
 
 # serde
 serde = { version = "1.0", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ redundant-clone = "warn"
 [workspace.dependencies]
 alloy-primitives = { version = "1.4", default-features = false }
 alloy-rlp = { version = "0.3", default-features = false }
-once_cell = { version = "1.20", default-features = false, features = ["critical-section"] }
+once_cell = { version = "1.20", default-features = false, features = ["alloc", "race"] }
 
 # serde
 serde = { version = "1.0", default-features = false, features = [

--- a/crates/eip7928/Cargo.toml
+++ b/crates/eip7928/Cargo.toml
@@ -28,7 +28,7 @@ workspace = true
 [dependencies]
 alloy-primitives = { workspace = true, features = ["map"] }
 alloy-rlp = { workspace = true, features = ["derive"] }
-once_cell = "1.20"
+once_cell.workspace = true
 
 # serde
 serde = { workspace = true, optional = true }
@@ -46,7 +46,7 @@ serde_json.workspace = true
 
 [features]
 default = ["std"]
-std = ["alloy-primitives/std", "alloy-rlp/std", "serde?/std", "borsh?/std"]
+std = ["alloy-primitives/std", "alloy-rlp/std", "once_cell/std", "serde?/std", "borsh?/std"]
 borsh = ["dep:borsh", "alloy-primitives/borsh"]
 rlp = ["alloy-primitives/rlp"]
 serde = ["dep:serde", "alloy-primitives/serde"]

--- a/crates/eip7928/Cargo.toml
+++ b/crates/eip7928/Cargo.toml
@@ -28,6 +28,7 @@ workspace = true
 [dependencies]
 alloy-primitives = { workspace = true, features = ["map"] }
 alloy-rlp = { workspace = true, features = ["derive"] }
+once_cell = "1.20"
 
 # serde
 serde = { workspace = true, optional = true }

--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -3,6 +3,13 @@
 use crate::account_changes::AccountChanges;
 use alloc::vec::Vec;
 
+#[cfg(feature = "rlp")]
+use once_cell as _;
+#[cfg(all(feature = "rlp", not(feature = "std")))]
+use once_cell::sync::OnceCell as OnceLock;
+#[cfg(all(feature = "rlp", feature = "std"))]
+use std::sync::OnceLock;
+
 /// This struct is used to store `account_changes` in a block.
 pub type BlockAccessList = Vec<AccountChanges>;
 
@@ -42,6 +49,8 @@ pub fn total_bal_items(bal: &[AccountChanges]) -> u64 {
 
 /// Block-Level Access List wrapper type with helper methods for metrics and validation.
 pub mod bal {
+    #[cfg(feature = "rlp")]
+    use super::OnceLock;
     use crate::account_changes::AccountChanges;
     use alloc::vec::{IntoIter, Vec};
     use alloy_primitives::Bytes;
@@ -247,8 +256,7 @@ pub mod bal {
 
     /// A decoded block access list with lazy hash computation.
     ///
-    /// This type wraps a decoded [`Bal`] along with the original raw RLP bytes,
-    /// allowing efficient hash computation on demand without re-encoding.
+    /// This type wraps a decoded [`Bal`] along with the original raw RLP bytes.
     #[derive(Clone, Debug, PartialEq, Eq)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub struct DecodedBal {
@@ -259,7 +267,7 @@ pub mod bal {
         /// Lazily computed hash of the block access list.
         #[cfg(feature = "rlp")]
         #[cfg_attr(feature = "serde", serde(skip, default))]
-        hash: core::cell::OnceCell<alloy_primitives::B256>,
+        hash: OnceLock<alloy_primitives::B256>,
     }
 
     impl DecodedBal {
@@ -269,7 +277,7 @@ pub mod bal {
                 decoded,
                 raw,
                 #[cfg(feature = "rlp")]
-                hash: core::cell::OnceCell::new(),
+                hash: OnceLock::new(),
             }
         }
 
@@ -303,6 +311,14 @@ pub mod bal {
         /// Consumes this struct and returns the decoded block access list and raw bytes.
         pub fn into_inner(self) -> (Bal, Bytes) {
             (self.decoded, self.raw)
+        }
+
+        /// Splits this struct into the decoded BAL, raw bytes, and hash.
+        #[cfg(feature = "rlp")]
+        pub fn split(self) -> (Bal, Bytes, alloy_primitives::B256) {
+            let hash = self.hash();
+            let (decoded, raw) = self.into_inner();
+            (decoded, raw, hash)
         }
 
         /// Consumes this struct and returns the decoded BAL together with its hash.
@@ -400,6 +416,11 @@ mod tests {
         assert_eq!(decoded.hash(), bal.compute_hash());
         assert_eq!(decoded.as_sealed_bal().hash(), bal.compute_hash());
         assert_eq!(decoded.as_sealed_bal().inner(), &decoded.as_bal());
+
+        let (split_bal, split_raw, split_hash) = decoded.clone().split();
+        assert_eq!(split_bal, bal);
+        assert_eq!(split_raw, raw);
+        assert_eq!(split_hash, bal.compute_hash());
 
         let sealed = decoded.into_sealed();
         assert_eq!(sealed.hash(), bal.compute_hash());

--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -3,11 +3,10 @@
 use crate::account_changes::AccountChanges;
 use alloc::vec::Vec;
 
-#[cfg(feature = "rlp")]
 use once_cell as _;
-#[cfg(all(feature = "rlp", not(feature = "std")))]
+#[cfg(not(feature = "std"))]
 use once_cell::sync::OnceCell as OnceLock;
-#[cfg(all(feature = "rlp", feature = "std"))]
+#[cfg(feature = "std")]
 use std::sync::OnceLock;
 
 /// This struct is used to store `account_changes` in a block.
@@ -49,7 +48,6 @@ pub fn total_bal_items(bal: &[AccountChanges]) -> u64 {
 
 /// Block-Level Access List wrapper type with helper methods for metrics and validation.
 pub mod bal {
-    #[cfg(feature = "rlp")]
     use super::OnceLock;
     use crate::account_changes::AccountChanges;
     use alloc::vec::{IntoIter, Vec};
@@ -269,7 +267,6 @@ pub mod bal {
         /// The original raw RLP bytes.
         raw: Bytes,
         /// Lazily computed hash of the block access list.
-        #[cfg(feature = "rlp")]
         #[cfg_attr(feature = "serde", serde(skip, default))]
         hash: OnceLock<alloy_primitives::B256>,
     }
@@ -277,12 +274,7 @@ pub mod bal {
     impl DecodedBal {
         /// Creates a new [`DecodedBal`] from decoded data and raw bytes.
         pub const fn new(decoded: Bal, raw: Bytes) -> Self {
-            Self {
-                decoded,
-                raw,
-                #[cfg(feature = "rlp")]
-                hash: OnceLock::new(),
-            }
+            Self { decoded, raw, hash: OnceLock::new() }
         }
 
         /// Creates a new [`DecodedBal`] by decoding from raw RLP bytes.
@@ -318,7 +310,6 @@ pub mod bal {
         }
 
         /// Splits this struct into the decoded BAL, raw bytes, and hash.
-        #[cfg(feature = "rlp")]
         pub fn into_parts(self) -> (Bal, Bytes, alloy_primitives::B256) {
             let hash = self.hash();
             let (decoded, raw) = self.split();
@@ -336,7 +327,6 @@ pub mod bal {
         /// Returns the hash of this block access list.
         ///
         /// The hash is computed lazily on first call and cached for subsequent calls.
-        #[cfg(feature = "rlp")]
         pub fn hash(&self) -> alloy_primitives::B256 {
             *self.hash.get_or_init(|| alloy_primitives::keccak256(self.raw.as_ref()))
         }
@@ -362,6 +352,25 @@ pub mod bal {
         fn length(&self) -> usize {
             self.raw.len()
         }
+    }
+}
+
+#[cfg(test)]
+mod hash_tests {
+    use super::bal::{Bal, DecodedBal};
+    use alloy_primitives::Bytes;
+
+    #[test]
+    fn decoded_bal_hash_uses_raw_bytes_without_rlp_feature() {
+        let raw = Bytes::from_static(&[0xc0]);
+        let decoded = DecodedBal::new(Bal::default(), raw.clone());
+
+        assert_eq!(decoded.hash(), alloy_primitives::keccak256(raw.as_ref()));
+
+        let (bal, split_raw, split_hash) = decoded.into_parts();
+        assert!(bal.is_empty());
+        assert_eq!(split_raw, raw);
+        assert_eq!(split_hash, alloy_primitives::keccak256(raw.as_ref()));
     }
 }
 

--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -66,7 +66,10 @@ pub mod bal {
     /// underlying data while providing additional utility methods for BAL analysis.
     #[derive(Clone, Debug, Default, PartialEq, Eq)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "rlp", derive(alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable))]
+    #[cfg_attr(
+        feature = "rlp",
+        derive(alloy_rlp::RlpEncodableWrapper, alloy_rlp::RlpDecodableWrapper)
+    )]
     #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
     #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
     pub struct Bal(Vec<AccountChanges>);
@@ -256,7 +259,8 @@ pub mod bal {
 
     /// A decoded block access list with lazy hash computation.
     ///
-    /// This type wraps a decoded [`Bal`] along with the original raw RLP bytes.
+    /// This type wraps a decoded [`Bal`] along with the original raw RLP bytes,
+    /// allowing efficient hash computation on demand without re-encoding.
     #[derive(Clone, Debug, PartialEq, Eq)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub struct DecodedBal {
@@ -334,7 +338,7 @@ pub mod bal {
         /// The hash is computed lazily on first call and cached for subsequent calls.
         #[cfg(feature = "rlp")]
         pub fn hash(&self) -> alloy_primitives::B256 {
-            *self.hash.get_or_init(|| self.decoded.compute_hash())
+            *self.hash.get_or_init(|| alloy_primitives::keccak256(self.raw.as_ref()))
         }
     }
 
@@ -414,6 +418,7 @@ mod tests {
         assert_eq!(decoded.as_bal(), &bal);
         assert_eq!(decoded.as_raw(), &raw);
         assert_eq!(decoded.hash(), bal.compute_hash());
+        assert_eq!(decoded.hash(), alloy_primitives::keccak256(raw.as_ref()));
         assert_eq!(decoded.as_sealed_bal().hash(), bal.compute_hash());
         assert_eq!(decoded.as_sealed_bal().inner(), &decoded.as_bal());
 

--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -3,9 +3,8 @@
 use crate::account_changes::AccountChanges;
 use alloc::vec::Vec;
 
-use once_cell as _;
 #[cfg(not(feature = "std"))]
-use once_cell::sync::OnceCell as OnceLock;
+use once_cell::race::OnceBox as OnceLock;
 #[cfg(feature = "std")]
 use std::sync::OnceLock;
 
@@ -259,7 +258,7 @@ pub mod bal {
     ///
     /// This type wraps a decoded [`Bal`] along with the original raw RLP bytes,
     /// allowing efficient hash computation on demand without re-encoding.
-    #[derive(Clone, Debug, PartialEq, Eq)]
+    #[derive(Clone, Debug)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub struct DecodedBal {
         /// The decoded block access list.
@@ -270,6 +269,14 @@ pub mod bal {
         #[cfg_attr(feature = "serde", serde(skip, default))]
         hash: OnceLock<alloy_primitives::B256>,
     }
+
+    impl PartialEq for DecodedBal {
+        fn eq(&self, other: &Self) -> bool {
+            self.decoded == other.decoded && self.raw == other.raw
+        }
+    }
+
+    impl Eq for DecodedBal {}
 
     impl DecodedBal {
         /// Creates a new [`DecodedBal`] from decoded data and raw bytes.
@@ -328,7 +335,7 @@ pub mod bal {
         ///
         /// The hash is computed lazily on first call and cached for subsequent calls.
         pub fn hash(&self) -> alloy_primitives::B256 {
-            *self.hash.get_or_init(|| alloy_primitives::keccak256(self.raw.as_ref()))
+            *self.hash.get_or_init(|| alloy_primitives::keccak256(self.raw.as_ref()).into())
         }
     }
 

--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -45,6 +45,8 @@ pub mod bal {
     use crate::account_changes::AccountChanges;
     use alloc::vec::{IntoIter, Vec};
     use alloy_primitives::Bytes;
+    #[cfg(feature = "rlp")]
+    use alloy_primitives::{Sealable, Sealed};
     use core::{
         ops::{Deref, Index},
         slice::Iter,
@@ -75,7 +77,7 @@ pub mod bal {
     }
 
     #[cfg(feature = "rlp")]
-    impl alloy_primitives::Sealable for Bal {
+    impl Sealable for Bal {
         fn hash_slow(&self) -> alloy_primitives::B256 {
             self.compute_hash()
         }
@@ -294,9 +296,23 @@ pub mod bal {
             &self.raw
         }
 
+        /// Returns the decoded BAL as a sealed borrowed value.
+        #[cfg(feature = "rlp")]
+        pub fn as_sealed_bal(&self) -> Sealed<&Bal> {
+            self.decoded.seal_ref_unchecked(self.hash())
+        }
+
         /// Consumes this struct and returns the decoded block access list and raw bytes.
         pub fn into_inner(self) -> (Bal, Bytes) {
             (self.decoded, self.raw)
+        }
+
+        /// Consumes this struct and returns the decoded BAL together with its hash.
+        #[cfg(feature = "rlp")]
+        pub fn into_sealed(self) -> Sealed<Bal> {
+            let seal = self.hash();
+            let (decoded, _) = self.into_inner();
+            decoded.seal_unchecked(seal)
         }
 
         /// Returns the hash of this block access list.
@@ -384,6 +400,12 @@ mod tests {
         assert_eq!(decoded.as_bal(), &bal);
         assert_eq!(decoded.as_raw(), &raw);
         assert_eq!(decoded.hash(), bal.compute_hash());
+        assert_eq!(decoded.as_sealed_bal().hash(), bal.compute_hash());
+        assert_eq!(decoded.as_sealed_bal().inner(), &decoded.as_bal());
+
+        let sealed = decoded.into_sealed();
+        assert_eq!(sealed.hash(), bal.compute_hash());
+        assert_eq!(sealed.inner(), &bal);
     }
 
     #[test]

--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -335,6 +335,7 @@ pub mod bal {
         ///
         /// The hash is computed lazily on first call and cached for subsequent calls.
         pub fn hash(&self) -> alloy_primitives::B256 {
+            #[allow(clippy::useless_conversion)]
             *self.hash.get_or_init(|| alloy_primitives::keccak256(self.raw.as_ref()).into())
         }
     }

--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -264,7 +264,7 @@ pub mod bal {
 
     impl DecodedBal {
         /// Creates a new [`DecodedBal`] from decoded data and raw bytes.
-        pub fn new(decoded: Bal, raw: Bytes) -> Self {
+        pub const fn new(decoded: Bal, raw: Bytes) -> Self {
             Self {
                 decoded,
                 raw,
@@ -285,12 +285,12 @@ pub mod bal {
         }
 
         /// Returns a reference to the decoded block access list.
-        pub fn as_bal(&self) -> &Bal {
+        pub const fn as_bal(&self) -> &Bal {
             &self.decoded
         }
 
         /// Returns the original raw RLP bytes.
-        pub fn as_raw(&self) -> &Bytes {
+        pub const fn as_raw(&self) -> &Bytes {
             &self.raw
         }
 

--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -45,8 +45,6 @@ pub mod bal {
     use crate::account_changes::AccountChanges;
     use alloc::vec::{IntoIter, Vec};
     use alloy_primitives::Bytes;
-    #[cfg(feature = "rlp")]
-    use alloy_primitives::{Sealable, Sealed};
     use core::{
         ops::{Deref, Index},
         slice::Iter,
@@ -77,7 +75,7 @@ pub mod bal {
     }
 
     #[cfg(feature = "rlp")]
-    impl Sealable for Bal {
+    impl alloy_primitives::Sealable for Bal {
         fn hash_slow(&self) -> alloy_primitives::B256 {
             self.compute_hash()
         }
@@ -298,8 +296,8 @@ pub mod bal {
 
         /// Returns the decoded BAL as a sealed borrowed value.
         #[cfg(feature = "rlp")]
-        pub fn as_sealed_bal(&self) -> Sealed<&Bal> {
-            self.decoded.seal_ref_unchecked(self.hash())
+        pub fn as_sealed_bal(&self) -> alloy_primitives::Sealed<&Bal> {
+            alloy_primitives::Sealable::seal_ref_unchecked(&self.decoded, self.hash())
         }
 
         /// Consumes this struct and returns the decoded block access list and raw bytes.
@@ -309,10 +307,10 @@ pub mod bal {
 
         /// Consumes this struct and returns the decoded BAL together with its hash.
         #[cfg(feature = "rlp")]
-        pub fn into_sealed(self) -> Sealed<Bal> {
+        pub fn into_sealed(self) -> alloy_primitives::Sealed<Bal> {
             let seal = self.hash();
             let (decoded, _) = self.into_inner();
-            decoded.seal_unchecked(seal)
+            alloy_primitives::Sealable::seal_unchecked(decoded, seal)
         }
 
         /// Returns the hash of this block access list.

--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -312,16 +312,16 @@ pub mod bal {
             alloy_primitives::Sealable::seal_ref_unchecked(&self.decoded, self.hash())
         }
 
-        /// Consumes this struct and returns the decoded block access list and raw bytes.
-        pub fn into_inner(self) -> (Bal, Bytes) {
+        /// Splits this struct into the decoded BAL and raw bytes.
+        pub fn split(self) -> (Bal, Bytes) {
             (self.decoded, self.raw)
         }
 
         /// Splits this struct into the decoded BAL, raw bytes, and hash.
         #[cfg(feature = "rlp")]
-        pub fn split(self) -> (Bal, Bytes, alloy_primitives::B256) {
+        pub fn into_parts(self) -> (Bal, Bytes, alloy_primitives::B256) {
             let hash = self.hash();
-            let (decoded, raw) = self.into_inner();
+            let (decoded, raw) = self.split();
             (decoded, raw, hash)
         }
 
@@ -329,7 +329,7 @@ pub mod bal {
         #[cfg(feature = "rlp")]
         pub fn into_sealed(self) -> alloy_primitives::Sealed<Bal> {
             let seal = self.hash();
-            let (decoded, _) = self.into_inner();
+            let (decoded, _) = self.split();
             alloy_primitives::Sealable::seal_unchecked(decoded, seal)
         }
 
@@ -422,7 +422,11 @@ mod tests {
         assert_eq!(decoded.as_sealed_bal().hash(), bal.compute_hash());
         assert_eq!(decoded.as_sealed_bal().inner(), &decoded.as_bal());
 
-        let (split_bal, split_raw, split_hash) = decoded.clone().split();
+        let (split_bal, split_raw) = decoded.clone().split();
+        assert_eq!(split_bal, bal);
+        assert_eq!(split_raw, raw);
+
+        let (split_bal, split_raw, split_hash) = decoded.clone().into_parts();
         assert_eq!(split_bal, bal);
         assert_eq!(split_raw, raw);
         assert_eq!(split_hash, bal.compute_hash());

--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -44,6 +44,7 @@ pub fn total_bal_items(bal: &[AccountChanges]) -> u64 {
 pub mod bal {
     use crate::account_changes::AccountChanges;
     use alloc::vec::{IntoIter, Vec};
+    use alloy_primitives::Bytes;
     use core::{
         ops::{Deref, Index},
         slice::Iter,
@@ -70,6 +71,13 @@ pub mod bal {
     impl From<Vec<AccountChanges>> for Bal {
         fn from(list: Vec<AccountChanges>) -> Self {
             Self(list)
+        }
+    }
+
+    #[cfg(feature = "rlp")]
+    impl alloy_primitives::Sealable for Bal {
+        fn hash_slow(&self) -> alloy_primitives::B256 {
+            self.compute_hash()
         }
     }
 
@@ -235,5 +243,159 @@ pub mod bal {
         pub nonce: usize,
         /// Total number of code changes.
         pub code: usize,
+    }
+
+    /// A decoded block access list with lazy hash computation.
+    ///
+    /// This type wraps a decoded [`Bal`] along with the original raw RLP bytes,
+    /// allowing efficient hash computation on demand without re-encoding.
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    pub struct DecodedBal {
+        /// The decoded block access list.
+        decoded: Bal,
+        /// The original raw RLP bytes.
+        raw: Bytes,
+        /// Lazily computed hash of the block access list.
+        #[cfg(feature = "rlp")]
+        #[cfg_attr(feature = "serde", serde(skip, default))]
+        hash: core::cell::OnceCell<alloy_primitives::B256>,
+    }
+
+    impl DecodedBal {
+        /// Creates a new [`DecodedBal`] from decoded data and raw bytes.
+        pub fn new(decoded: Bal, raw: Bytes) -> Self {
+            Self {
+                decoded,
+                raw,
+                #[cfg(feature = "rlp")]
+                hash: core::cell::OnceCell::new(),
+            }
+        }
+
+        /// Creates a new [`DecodedBal`] by decoding from raw RLP bytes.
+        #[cfg(feature = "rlp")]
+        pub fn from_rlp_bytes(raw: Bytes) -> Result<Self, alloy_rlp::Error> {
+            let mut slice = raw.as_ref();
+            let decoded = <Bal as alloy_rlp::Decodable>::decode(&mut slice)?;
+            if !slice.is_empty() {
+                return Err(alloy_rlp::Error::UnexpectedLength);
+            }
+            Ok(Self::new(decoded, raw))
+        }
+
+        /// Returns a reference to the decoded block access list.
+        pub fn as_bal(&self) -> &Bal {
+            &self.decoded
+        }
+
+        /// Returns the original raw RLP bytes.
+        pub fn as_raw(&self) -> &Bytes {
+            &self.raw
+        }
+
+        /// Consumes this struct and returns the decoded block access list and raw bytes.
+        pub fn into_inner(self) -> (Bal, Bytes) {
+            (self.decoded, self.raw)
+        }
+
+        /// Returns the hash of this block access list.
+        ///
+        /// The hash is computed lazily on first call and cached for subsequent calls.
+        #[cfg(feature = "rlp")]
+        pub fn hash(&self) -> alloy_primitives::B256 {
+            *self.hash.get_or_init(|| self.decoded.compute_hash())
+        }
+    }
+
+    #[cfg(feature = "rlp")]
+    impl alloy_rlp::Decodable for DecodedBal {
+        fn decode(buf: &mut &[u8]) -> Result<Self, alloy_rlp::Error> {
+            let original = *buf;
+            let decoded = <Bal as alloy_rlp::Decodable>::decode(buf)?;
+            let consumed = original.len() - buf.len();
+            let raw = Bytes::copy_from_slice(&original[..consumed]);
+            Ok(Self::new(decoded, raw))
+        }
+    }
+
+    #[cfg(feature = "rlp")]
+    impl alloy_rlp::Encodable for DecodedBal {
+        fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
+            out.put_slice(&self.raw);
+        }
+
+        fn length(&self) -> usize {
+            self.raw.len()
+        }
+    }
+}
+
+#[cfg(all(test, feature = "rlp"))]
+mod tests {
+    use super::bal::{Bal, DecodedBal};
+    use crate::{
+        AccountChanges, BalanceChange, CodeChange, NonceChange, SlotChanges, StorageChange,
+        constants::EMPTY_BLOCK_ACCESS_LIST_HASH,
+    };
+    use alloy_primitives::{Address, Bytes, U256};
+
+    fn sample_bal() -> Bal {
+        Bal::new(vec![
+            AccountChanges::new(Address::from([0x11; 20]))
+                .with_storage_read(U256::from(0x10))
+                .with_storage_change(SlotChanges::new(
+                    U256::from(0x01),
+                    vec![StorageChange::new(0, U256::from(0xaa))],
+                ))
+                .with_balance_change(BalanceChange::new(1, U256::from(1_000)))
+                .with_nonce_change(NonceChange::new(2, 7))
+                .with_code_change(CodeChange::new(3, Bytes::from(vec![0x60, 0x00]))),
+            AccountChanges::new(Address::from([0x22; 20]))
+                .with_storage_read(U256::from(0x20))
+                .with_storage_change(SlotChanges::new(
+                    U256::from(0x02),
+                    vec![StorageChange::new(4, U256::from(0xbb))],
+                )),
+        ])
+    }
+
+    #[test]
+    fn bal_compute_hash_returns_empty_hash_for_empty_bal() {
+        let bal = Bal::default();
+
+        assert_eq!(bal.compute_hash(), EMPTY_BLOCK_ACCESS_LIST_HASH);
+    }
+
+    #[test]
+    fn bal_compute_hash_matches_free_function_for_non_empty_bal() {
+        let bal = sample_bal();
+
+        assert_eq!(bal.compute_hash(), super::compute_block_access_list_hash(bal.as_slice()));
+        assert_ne!(bal.compute_hash(), EMPTY_BLOCK_ACCESS_LIST_HASH);
+    }
+
+    #[test]
+    fn decoded_bal_from_rlp_bytes_preserves_raw_and_hash() {
+        let bal = sample_bal();
+        let raw = Bytes::from(alloy_rlp::encode(&bal));
+        let decoded = DecodedBal::from_rlp_bytes(raw.clone()).unwrap();
+
+        assert_eq!(decoded.as_bal(), &bal);
+        assert_eq!(decoded.as_raw(), &raw);
+        assert_eq!(decoded.hash(), bal.compute_hash());
+    }
+
+    #[test]
+    fn decoded_bal_decode_consumes_exact_raw_rlp_item() {
+        let bal = sample_bal();
+        let raw = alloy_rlp::encode(&bal);
+        let mut buf = raw.as_ref();
+        let decoded = <DecodedBal as alloy_rlp::Decodable>::decode(&mut buf).unwrap();
+
+        assert!(buf.is_empty());
+        assert_eq!(decoded.as_bal(), &bal);
+        assert_eq!(decoded.as_raw().as_ref(), raw.as_slice());
+        assert_eq!(alloy_rlp::encode(&decoded), raw);
     }
 }


### PR DESCRIPTION
## Summary
- add `bal::DecodedBal` for a decoded BAL plus its original RLP bytes
- add BAL sealing and decomposition helpers: `as_sealed_bal`, `into_sealed`, `split`, and `into_parts`
- move `once_cell` to workspace dependencies and use the Alloy `OnceLock` pattern: `std::sync::OnceLock` on `std`, `once_cell::race::OnceBox` on `no_std`
- make `DecodedBal` hash from the captured raw RLP bytes by switching `Bal` to the wrapper RLP derives
- fix `--no-default-features` CI by replacing the `critical-section` backend with `alloc + race`

## Validation
- `cargo test -p alloy-eip7928 --no-default-features`
- `cargo test -p alloy-eip7928`
- `cargo test -p alloy-eip7928 --all-features`
- `cargo test --workspace --no-default-features`