### PR TITLE
docs: add missing EIPs to current support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,7 @@ EIP implementations apart from the ones listed below can be found in [alloy-rs/a
 
 ## Current support
 
+- [EIP-2124](https://eips.ethereum.org/EIPS/eip-2124)
 - [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930)
 - [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702)
+- [EIP-7928](https://eips.ethereum.org/EIPS/eip-7928)


### PR DESCRIPTION
## Summary
- add the missing `EIP-2124` entry to the README support list
- add the missing `EIP-7928` entry to the README support list
- keep the list ordered by EIP number

## Testing
- not run (README-only change)