### PR TITLE
chore: newtype for BlockAccessIndex.

### DIFF
--- a/crates/eip7928/src/account_changes.rs
+++ b/crates/eip7928/src/account_changes.rs
@@ -186,7 +186,7 @@ impl AccountChanges {
 
 #[cfg(test)]
 mod sort_tests {
-    use crate::StorageChange;
+    use crate::{BlockAccessIndex, StorageChange};
 
     use super::*;
     use alloy_primitives::Bytes;
@@ -199,27 +199,30 @@ mod sort_tests {
                 SlotChanges::new(
                     U256::from(3),
                     vec![
-                        StorageChange::new(8, U256::from(0x80)),
-                        StorageChange::new(2, U256::from(0x20)),
+                        StorageChange::new(BlockAccessIndex::new(8), U256::from(0x80)),
+                        StorageChange::new(BlockAccessIndex::new(2), U256::from(0x20)),
                     ],
                 ),
                 SlotChanges::new(
                     U256::from(1),
                     vec![
-                        StorageChange::new(5, U256::from(0x50)),
-                        StorageChange::new(1, U256::from(0x10)),
+                        StorageChange::new(BlockAccessIndex::new(5), U256::from(0x50)),
+                        StorageChange::new(BlockAccessIndex::new(1), U256::from(0x10)),
                     ],
                 ),
             ],
             storage_reads: vec![U256::from(4), U256::from(2)],
             balance_changes: vec![
-                BalanceChange::new(6, U256::from(600)),
-                BalanceChange::new(3, U256::from(300)),
+                BalanceChange::new(BlockAccessIndex::new(6), U256::from(600)),
+                BalanceChange::new(BlockAccessIndex::new(3), U256::from(300)),
             ],
-            nonce_changes: vec![NonceChange::new(7, 70), NonceChange::new(4, 40)],
+            nonce_changes: vec![
+                NonceChange::new(BlockAccessIndex::new(7), 70),
+                NonceChange::new(BlockAccessIndex::new(4), 40),
+            ],
             code_changes: vec![
-                CodeChange::new(9, Bytes::from_static(&[0x60, 0x09])),
-                CodeChange::new(5, Bytes::from_static(&[0x60, 0x05])),
+                CodeChange::new(BlockAccessIndex::new(9), Bytes::from_static(&[0x60, 0x09])),
+                CodeChange::new(BlockAccessIndex::new(5), Bytes::from_static(&[0x60, 0x05])),
             ],
         };
 
@@ -235,7 +238,7 @@ mod sort_tests {
                 .iter()
                 .map(|change| change.block_access_index)
                 .collect::<Vec<_>>(),
-            vec![1, 5]
+            vec![BlockAccessIndex::new(1), BlockAccessIndex::new(5)]
         );
         assert_eq!(
             account.storage_changes[1]
@@ -243,7 +246,7 @@ mod sort_tests {
                 .iter()
                 .map(|change| change.block_access_index)
                 .collect::<Vec<_>>(),
-            vec![2, 8]
+            vec![BlockAccessIndex::new(2), BlockAccessIndex::new(8)]
         );
         assert_eq!(account.storage_reads, vec![U256::from(2), U256::from(4)]);
         assert_eq!(
@@ -252,7 +255,7 @@ mod sort_tests {
                 .iter()
                 .map(|change| change.block_access_index)
                 .collect::<Vec<_>>(),
-            vec![3, 6]
+            vec![BlockAccessIndex::new(3), BlockAccessIndex::new(6)]
         );
         assert_eq!(
             account
@@ -260,18 +263,18 @@ mod sort_tests {
                 .iter()
                 .map(|change| change.block_access_index)
                 .collect::<Vec<_>>(),
-            vec![4, 7]
+            vec![BlockAccessIndex::new(4), BlockAccessIndex::new(7)]
         );
         assert_eq!(
             account.code_changes.iter().map(|change| change.block_access_index).collect::<Vec<_>>(),
-            vec![5, 9]
+            vec![BlockAccessIndex::new(5), BlockAccessIndex::new(9)]
         );
     }
 }
 
 #[cfg(test)]
 mod post_state_tests {
-    use crate::StorageChange;
+    use crate::{BlockAccessIndex, StorageChange};
 
     use super::*;
 
@@ -281,15 +284,15 @@ mod post_state_tests {
             .with_storage_change(SlotChanges::new(
                 U256::from(1),
                 vec![
-                    StorageChange::new(0, U256::from(0xaa)),
-                    StorageChange::new(2, U256::from(0xbb)),
+                    StorageChange::new(BlockAccessIndex::new(0), U256::from(0xaa)),
+                    StorageChange::new(BlockAccessIndex::new(2), U256::from(0xbb)),
                 ],
             ))
             .with_storage_change(SlotChanges::new(
                 U256::from(3),
                 vec![
-                    StorageChange::new(1, U256::from(0xcc)),
-                    StorageChange::new(3, U256::from(0xdd)),
+                    StorageChange::new(BlockAccessIndex::new(1), U256::from(0xcc)),
+                    StorageChange::new(BlockAccessIndex::new(3), U256::from(0xdd)),
                 ],
             ));
 
@@ -304,7 +307,7 @@ mod post_state_tests {
 
 #[cfg(all(test, feature = "serde"))]
 mod tests {
-    use crate::StorageChange;
+    use crate::{BlockAccessIndex, StorageChange};
 
     use super::*;
     use alloy_primitives::Bytes;
@@ -317,18 +320,21 @@ mod tests {
             storage_changes: vec![SlotChanges {
                 slot: U256::from(1),
                 changes: vec![StorageChange {
-                    block_access_index: 0u64,
+                    block_access_index: BlockAccessIndex::new(0),
                     new_value: U256::from(100),
                 }],
             }],
             storage_reads: vec![U256::from(2)],
             balance_changes: vec![BalanceChange {
-                block_access_index: 1u64,
+                block_access_index: BlockAccessIndex::new(1),
                 post_balance: U256::from(1000),
             }],
-            nonce_changes: vec![NonceChange { block_access_index: 2u64, new_nonce: 42 }],
+            nonce_changes: vec![NonceChange {
+                block_access_index: BlockAccessIndex::new(2),
+                new_nonce: 42,
+            }],
             code_changes: vec![CodeChange {
-                block_access_index: 3u64,
+                block_access_index: BlockAccessIndex::new(3),
                 new_code: Bytes::from(vec![0x60, 0x00]),
             }],
         };
@@ -344,7 +350,7 @@ mod tests {
         let acc1 = AccountChanges::new(Address::from([0x11; 20]))
             .with_storage_read(U256::from(1))
             .with_balance_change(BalanceChange {
-                block_access_index: 0u64,
+                block_access_index: BlockAccessIndex::new(0),
                 post_balance: U256::from(100),
             });
 
@@ -352,14 +358,17 @@ mod tests {
             .with_storage_change(SlotChanges {
                 slot: U256::from(2),
                 changes: vec![StorageChange {
-                    block_access_index: 1u64,
+                    block_access_index: BlockAccessIndex::new(1),
                     new_value: U256::from(200),
                 }],
             })
-            .with_nonce_change(NonceChange { block_access_index: 2u64, new_nonce: 42 });
+            .with_nonce_change(NonceChange {
+                block_access_index: BlockAccessIndex::new(2),
+                new_nonce: 42,
+            });
 
         let acc3 = AccountChanges::new(Address::from([0x33; 20])).with_code_change(CodeChange {
-            block_access_index: 3u64,
+            block_access_index: BlockAccessIndex::new(3),
             new_code: Bytes::from(vec![0x60, 0x00]),
         });
 

--- a/crates/eip7928/src/balance_change.rs
+++ b/crates/eip7928/src/balance_change.rs
@@ -13,7 +13,7 @@ use alloy_primitives::U256;
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct BalanceChange {
     /// The index of bal that stores balance change.
-    #[cfg_attr(feature = "serde", serde(alias = "txIndex", with = "crate::quantity"))]
+    #[cfg_attr(feature = "serde", serde(alias = "txIndex"))]
     pub block_access_index: BlockAccessIndex,
     /// The post-transaction balance of the account.
     pub post_balance: U256,

--- a/crates/eip7928/src/block_access_index.rs
+++ b/crates/eip7928/src/block_access_index.rs
@@ -16,10 +16,7 @@ use core::fmt;
 /// serializes as a hex `"quantity"` string (e.g. `"0x1a"`), matching the previous
 /// `BlockAccessIndex = u64` alias behavior when paired with the `crate::quantity` module.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(
-    feature = "rlp",
-    derive(alloy_rlp::RlpEncodableWrapper, alloy_rlp::RlpDecodableWrapper)
-)]
+#[cfg_attr(feature = "rlp", derive(alloy_rlp::RlpEncodableWrapper, alloy_rlp::RlpDecodableWrapper))]
 #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[repr(transparent)]
@@ -52,11 +49,11 @@ impl BlockAccessIndex {
     ///
     /// Returns:
     /// - `Some(BlockAccessPhase::PreExecution)` when the index is `0`.
-    /// - `Some(BlockAccessPhase::Transaction(i))` when the index is in `1..=tx_len`, with
-    ///   `i = index - 1` as a 0-based transaction index.
+    /// - `Some(BlockAccessPhase::Transaction(i))` when the index is in `1..=tx_len`, with `i =
+    ///   index - 1` as a 0-based transaction index.
     /// - `Some(BlockAccessPhase::PostExecution)` when the index is exactly `tx_len + 1`.
-    /// - `None` when the index is strictly greater than `tx_len + 1` (out of range
-    ///   for a block with `tx_len` transactions).
+    /// - `None` when the index is strictly greater than `tx_len + 1` (out of range for a block with
+    ///   `tx_len` transactions).
     #[inline]
     pub const fn phase(self, tx_len: usize) -> Option<BlockAccessPhase> {
         // Widen `tx_len` to `u64` to compare against the index without risking
@@ -127,10 +124,7 @@ mod tests {
     fn pre_execution_is_index_zero() {
         assert_eq!(BlockAccessIndex::new(0).phase(0), Some(BlockAccessPhase::PreExecution));
         assert_eq!(BlockAccessIndex::new(0).phase(5), Some(BlockAccessPhase::PreExecution));
-        assert_eq!(
-            BlockAccessIndex::PRE_EXECUTION.phase(5),
-            Some(BlockAccessPhase::PreExecution)
-        );
+        assert_eq!(BlockAccessIndex::PRE_EXECUTION.phase(5), Some(BlockAccessPhase::PreExecution));
     }
 
     #[test]

--- a/crates/eip7928/src/block_access_index.rs
+++ b/crates/eip7928/src/block_access_index.rs
@@ -1,0 +1,202 @@
+//! Contains the [`BlockAccessIndex`] newtype and its [`BlockAccessPhase`] classification.
+
+use core::fmt;
+
+/// Block access index within a block.
+///
+/// A block's indices are laid out as:
+/// - `0` — pre-execution (system contract calls, block-level setup, ...)
+/// - `1..=tx_len` — transaction execution (transaction index `i` maps to index `i + 1`)
+/// - `tx_len + 1` — post-execution (block rewards, withdrawals, ...)
+///
+/// Stored as a `u64` internally, but wrapped as a newtype so it cannot be accidentally
+/// confused with other `u64` indices (for example, an `account_id` passed alongside it).
+///
+/// RLP, borsh, and arbitrary representations are identical to the wrapped `u64`. Serde
+/// serializes as a hex `"quantity"` string (e.g. `"0x1a"`), matching the previous
+/// `BlockAccessIndex = u64` alias behavior when paired with the `crate::quantity` module.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(
+    feature = "rlp",
+    derive(alloy_rlp::RlpEncodableWrapper, alloy_rlp::RlpDecodableWrapper)
+)]
+#[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[repr(transparent)]
+pub struct BlockAccessIndex(pub u64);
+
+impl BlockAccessIndex {
+    /// Pre-execution slot (index `0`).
+    pub const PRE_EXECUTION: Self = Self(0);
+
+    /// Constructs a new [`BlockAccessIndex`] from a raw `u64`.
+    #[inline]
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Returns the raw `u64` value.
+    #[inline]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+
+    /// Bumps the index by 1.
+    #[inline]
+    pub const fn increment(&mut self) {
+        self.0 += 1;
+    }
+
+    /// Classifies this index into a [`BlockAccessPhase`], given the number of transactions
+    /// in the block.
+    ///
+    /// Returns:
+    /// - `Some(BlockAccessPhase::PreExecution)` when the index is `0`.
+    /// - `Some(BlockAccessPhase::Transaction(i))` when the index is in `1..=tx_len`, with
+    ///   `i = index - 1` as a 0-based transaction index.
+    /// - `Some(BlockAccessPhase::PostExecution)` when the index is exactly `tx_len + 1`.
+    /// - `None` when the index is strictly greater than `tx_len + 1` (out of range
+    ///   for a block with `tx_len` transactions).
+    #[inline]
+    pub const fn phase(self, tx_len: usize) -> Option<BlockAccessPhase> {
+        // Widen `tx_len` to `u64` to compare against the index without risking
+        // truncation on 32-bit targets.
+        let tx_len_u64 = tx_len as u64;
+        if self.0 == 0 {
+            Some(BlockAccessPhase::PreExecution)
+        } else if self.0 <= tx_len_u64 {
+            // `self.0 >= 1` here, so the subtraction cannot underflow.
+            // Casting back to `usize` is safe because `self.0 - 1 < tx_len <= usize::MAX`.
+            Some(BlockAccessPhase::Transaction((self.0 - 1) as usize))
+        } else if self.0 == tx_len_u64 + 1 {
+            Some(BlockAccessPhase::PostExecution)
+        } else {
+            None
+        }
+    }
+}
+
+impl fmt::Display for BlockAccessIndex {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl fmt::LowerHex for BlockAccessIndex {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for BlockAccessIndex {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        alloy_primitives::U64::from(self.0).serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for BlockAccessIndex {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        alloy_primitives::U64::deserialize(deserializer).map(|value| Self(value.to()))
+    }
+}
+
+/// Classification of a [`BlockAccessIndex`] within a block.
+///
+/// See [`BlockAccessIndex::phase`] for how indices map to phases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum BlockAccessPhase {
+    /// Pre-execution slot (index `0`).
+    PreExecution,
+    /// Transaction execution slot. The inner value is the 0-based transaction index
+    /// within the block (i.e. `block_access_index - 1`).
+    Transaction(usize),
+    /// Post-execution slot (index `tx_len + 1`).
+    PostExecution,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pre_execution_is_index_zero() {
+        assert_eq!(BlockAccessIndex::new(0).phase(0), Some(BlockAccessPhase::PreExecution));
+        assert_eq!(BlockAccessIndex::new(0).phase(5), Some(BlockAccessPhase::PreExecution));
+        assert_eq!(
+            BlockAccessIndex::PRE_EXECUTION.phase(5),
+            Some(BlockAccessPhase::PreExecution)
+        );
+    }
+
+    #[test]
+    fn transaction_indices_are_one_based() {
+        assert_eq!(BlockAccessIndex::new(1).phase(3), Some(BlockAccessPhase::Transaction(0)));
+        assert_eq!(BlockAccessIndex::new(2).phase(3), Some(BlockAccessPhase::Transaction(1)));
+        assert_eq!(BlockAccessIndex::new(3).phase(3), Some(BlockAccessPhase::Transaction(2)));
+    }
+
+    #[test]
+    fn post_execution_is_tx_len_plus_one() {
+        assert_eq!(BlockAccessIndex::new(4).phase(3), Some(BlockAccessPhase::PostExecution));
+        assert_eq!(BlockAccessIndex::new(1).phase(0), Some(BlockAccessPhase::PostExecution));
+    }
+
+    #[test]
+    fn out_of_range_returns_none() {
+        assert_eq!(BlockAccessIndex::new(5).phase(3), None);
+        assert_eq!(BlockAccessIndex::new(u64::MAX).phase(3), None);
+    }
+
+    #[test]
+    fn empty_block_has_only_pre_and_post() {
+        assert_eq!(BlockAccessIndex::new(0).phase(0), Some(BlockAccessPhase::PreExecution));
+        assert_eq!(BlockAccessIndex::new(1).phase(0), Some(BlockAccessPhase::PostExecution));
+        assert_eq!(BlockAccessIndex::new(2).phase(0), None);
+    }
+
+    #[test]
+    fn increment_bumps_by_one() {
+        let mut idx = BlockAccessIndex::new(3);
+        idx.increment();
+        assert_eq!(idx, BlockAccessIndex::new(4));
+    }
+
+    #[test]
+    fn new_and_get_roundtrip() {
+        let idx = BlockAccessIndex::new(42);
+        assert_eq!(idx.get(), 42);
+    }
+
+    #[test]
+    fn display_matches_inner() {
+        extern crate alloc;
+        assert_eq!(alloc::format!("{}", BlockAccessIndex::new(7)), "7");
+        assert_eq!(alloc::format!("{:x}", BlockAccessIndex::new(255)), "ff");
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_hex_quantity_roundtrip() {
+        let idx = BlockAccessIndex::new(26);
+        let json = serde_json::to_string(&idx).unwrap();
+        assert_eq!(json, "\"0x1a\"");
+        let back: BlockAccessIndex = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, idx);
+    }
+
+    #[cfg(feature = "rlp")]
+    #[test]
+    fn rlp_matches_raw_u64() {
+        use alloy_rlp::Decodable;
+        let idx = BlockAccessIndex::new(300);
+        let encoded = alloy_rlp::encode(idx);
+        assert_eq!(encoded, alloy_rlp::encode(300u64));
+        let decoded = BlockAccessIndex::decode(&mut encoded.as_slice()).unwrap();
+        assert_eq!(decoded, idx);
+    }
+}

--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -393,7 +393,8 @@ pub mod bal {
 mod hash_tests {
     use super::bal::{Bal, DecodedBal};
     use crate::{
-        AccountChanges, BalanceChange, CodeChange, NonceChange, SlotChanges, StorageChange,
+        AccountChanges, BalanceChange, BlockAccessIndex, CodeChange, NonceChange, SlotChanges,
+        StorageChange,
     };
     use alloy_primitives::{Address, Bytes, U256};
 
@@ -421,27 +422,30 @@ mod hash_tests {
                     SlotChanges::new(
                         U256::from(3),
                         vec![
-                            StorageChange::new(8, U256::from(0x80)),
-                            StorageChange::new(2, U256::from(0x20)),
+                            StorageChange::new(BlockAccessIndex::new(8), U256::from(0x80)),
+                            StorageChange::new(BlockAccessIndex::new(2), U256::from(0x20)),
                         ],
                     ),
                     SlotChanges::new(
                         U256::from(1),
                         vec![
-                            StorageChange::new(5, U256::from(0x50)),
-                            StorageChange::new(1, U256::from(0x10)),
+                            StorageChange::new(BlockAccessIndex::new(5), U256::from(0x50)),
+                            StorageChange::new(BlockAccessIndex::new(1), U256::from(0x10)),
                         ],
                     ),
                 ],
                 storage_reads: vec![U256::from(4), U256::from(2)],
                 balance_changes: vec![
-                    BalanceChange::new(6, U256::from(600)),
-                    BalanceChange::new(3, U256::from(300)),
+                    BalanceChange::new(BlockAccessIndex::new(6), U256::from(600)),
+                    BalanceChange::new(BlockAccessIndex::new(3), U256::from(300)),
                 ],
-                nonce_changes: vec![NonceChange::new(7, 70), NonceChange::new(4, 40)],
+                nonce_changes: vec![
+                    NonceChange::new(BlockAccessIndex::new(7), 70),
+                    NonceChange::new(BlockAccessIndex::new(4), 40),
+                ],
                 code_changes: vec![
-                    CodeChange::new(9, Bytes::from_static(&[0x60, 0x09])),
-                    CodeChange::new(5, Bytes::from_static(&[0x60, 0x05])),
+                    CodeChange::new(BlockAccessIndex::new(9), Bytes::from_static(&[0x60, 0x09])),
+                    CodeChange::new(BlockAccessIndex::new(5), Bytes::from_static(&[0x60, 0x05])),
                 ],
             },
             AccountChanges {
@@ -450,27 +454,30 @@ mod hash_tests {
                     SlotChanges::new(
                         U256::from(2),
                         vec![
-                            StorageChange::new(4, U256::from(0x40)),
-                            StorageChange::new(0, U256::from(0x00)),
+                            StorageChange::new(BlockAccessIndex::new(4), U256::from(0x40)),
+                            StorageChange::new(BlockAccessIndex::new(0), U256::from(0x00)),
                         ],
                     ),
                     SlotChanges::new(
                         U256::from(1),
                         vec![
-                            StorageChange::new(3, U256::from(0x30)),
-                            StorageChange::new(1, U256::from(0x10)),
+                            StorageChange::new(BlockAccessIndex::new(3), U256::from(0x30)),
+                            StorageChange::new(BlockAccessIndex::new(1), U256::from(0x10)),
                         ],
                     ),
                 ],
                 storage_reads: vec![U256::from(5), U256::from(3)],
                 balance_changes: vec![
-                    BalanceChange::new(5, U256::from(500)),
-                    BalanceChange::new(2, U256::from(200)),
+                    BalanceChange::new(BlockAccessIndex::new(5), U256::from(500)),
+                    BalanceChange::new(BlockAccessIndex::new(2), U256::from(200)),
                 ],
-                nonce_changes: vec![NonceChange::new(8, 80), NonceChange::new(1, 10)],
+                nonce_changes: vec![
+                    NonceChange::new(BlockAccessIndex::new(8), 80),
+                    NonceChange::new(BlockAccessIndex::new(1), 10),
+                ],
                 code_changes: vec![
-                    CodeChange::new(4, Bytes::from_static(&[0x60, 0x04])),
-                    CodeChange::new(2, Bytes::from_static(&[0x60, 0x02])),
+                    CodeChange::new(BlockAccessIndex::new(4), Bytes::from_static(&[0x60, 0x04])),
+                    CodeChange::new(BlockAccessIndex::new(2), Bytes::from_static(&[0x60, 0x02])),
                 ],
             },
         ]);
@@ -518,8 +525,8 @@ mod hash_tests {
 mod tests {
     use super::bal::{Bal, DecodedBal};
     use crate::{
-        AccountChanges, BalanceChange, CodeChange, NonceChange, SlotChanges, StorageChange,
-        constants::EMPTY_BLOCK_ACCESS_LIST_HASH,
+        AccountChanges, BalanceChange, BlockAccessIndex, CodeChange, NonceChange, SlotChanges,
+        StorageChange, constants::EMPTY_BLOCK_ACCESS_LIST_HASH,
     };
     use alloy_primitives::{Address, Bytes, U256};
 
@@ -529,16 +536,22 @@ mod tests {
                 .with_storage_read(U256::from(0x10))
                 .with_storage_change(SlotChanges::new(
                     U256::from(0x01),
-                    vec![StorageChange::new(0, U256::from(0xaa))],
+                    vec![StorageChange::new(BlockAccessIndex::new(0), U256::from(0xaa))],
                 ))
-                .with_balance_change(BalanceChange::new(1, U256::from(1_000)))
-                .with_nonce_change(NonceChange::new(2, 7))
-                .with_code_change(CodeChange::new(3, Bytes::from(vec![0x60, 0x00]))),
+                .with_balance_change(BalanceChange::new(
+                    BlockAccessIndex::new(1),
+                    U256::from(1_000),
+                ))
+                .with_nonce_change(NonceChange::new(BlockAccessIndex::new(2), 7))
+                .with_code_change(CodeChange::new(
+                    BlockAccessIndex::new(3),
+                    Bytes::from(vec![0x60, 0x00]),
+                )),
             AccountChanges::new(Address::from([0x22; 20]))
                 .with_storage_read(U256::from(0x20))
                 .with_storage_change(SlotChanges::new(
                     U256::from(0x02),
-                    vec![StorageChange::new(4, U256::from(0xbb))],
+                    vec![StorageChange::new(BlockAccessIndex::new(4), U256::from(0xbb))],
                 )),
         ])
     }

--- a/crates/eip7928/src/code_change.rs
+++ b/crates/eip7928/src/code_change.rs
@@ -12,7 +12,7 @@ use alloy_primitives::Bytes;
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CodeChange {
     /// The index of bal that stores this code change.
-    #[cfg_attr(feature = "serde", serde(alias = "txIndex", with = "crate::quantity"))]
+    #[cfg_attr(feature = "serde", serde(alias = "txIndex"))]
     pub block_access_index: BlockAccessIndex,
     /// The new code of the account.
     pub new_code: Bytes,

--- a/crates/eip7928/src/constants.rs
+++ b/crates/eip7928/src/constants.rs
@@ -26,9 +26,6 @@ pub const BAL_RETENTION_PERIOD_EPOCHS: u64 = 3_533;
 pub const BAL_RETENTION_PERIOD_SLOTS: u64 =
     BAL_RETENTION_PERIOD_EPOCHS * ETHEREUM_MAINNET_SLOTS_PER_EPOCH;
 
-/// Type alias for block index for eip-7928.
-pub type BlockAccessIndex = u64;
-
 /// The empty block access list hash.
 pub const EMPTY_BLOCK_ACCESS_LIST_HASH: B256 =
     b256!("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");

--- a/crates/eip7928/src/lib.rs
+++ b/crates/eip7928/src/lib.rs
@@ -11,6 +11,10 @@ extern crate alloc;
 pub mod constants;
 pub use constants::*;
 
+/// Module for the [`BlockAccessIndex`] newtype.
+pub mod block_access_index;
+pub use block_access_index::*;
+
 /// Module for handling storage changes within a block.
 pub mod storage_change;
 pub use storage_change::*;

--- a/crates/eip7928/src/nonce_change.rs
+++ b/crates/eip7928/src/nonce_change.rs
@@ -12,7 +12,7 @@ use crate::BlockAccessIndex;
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct NonceChange {
     /// The index of bal that stores this nonce change.
-    #[cfg_attr(feature = "serde", serde(alias = "txIndex", with = "crate::quantity"))]
+    #[cfg_attr(feature = "serde", serde(alias = "txIndex"))]
     pub block_access_index: BlockAccessIndex,
     /// The new nonce of the account.
     #[cfg_attr(feature = "serde", serde(alias = "postNonce", with = "crate::quantity"))]

--- a/crates/eip7928/src/slot_changes.rs
+++ b/crates/eip7928/src/slot_changes.rs
@@ -78,15 +78,16 @@ impl SlotChanges {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::BlockAccessIndex;
 
     #[test]
     fn sort_orders_changes_by_block_access_index() {
         let mut slot_changes = SlotChanges::new(
             U256::from(1),
             vec![
-                StorageChange::new(8, U256::from(0x80)),
-                StorageChange::new(2, U256::from(0x20)),
-                StorageChange::new(5, U256::from(0x50)),
+                StorageChange::new(BlockAccessIndex::new(8), U256::from(0x80)),
+                StorageChange::new(BlockAccessIndex::new(2), U256::from(0x20)),
+                StorageChange::new(BlockAccessIndex::new(5), U256::from(0x50)),
             ],
         );
 
@@ -94,7 +95,7 @@ mod tests {
 
         assert_eq!(
             slot_changes.changes.iter().map(|change| change.block_access_index).collect::<Vec<_>>(),
-            vec![2, 5, 8]
+            vec![BlockAccessIndex::new(2), BlockAccessIndex::new(5), BlockAccessIndex::new(8)]
         );
     }
 }

--- a/crates/eip7928/src/storage_change.rs
+++ b/crates/eip7928/src/storage_change.rs
@@ -13,7 +13,7 @@ use alloy_primitives::U256;
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct StorageChange {
     /// Index of the bal that stores the performed write.
-    #[cfg_attr(feature = "serde", serde(alias = "txIndex", with = "crate::quantity"))]
+    #[cfg_attr(feature = "serde", serde(alias = "txIndex"))]
     pub block_access_index: BlockAccessIndex,
     /// The new value written to the storage slot.
     #[cfg_attr(feature = "serde", serde(alias = "postValue"))]
@@ -33,9 +33,9 @@ impl StorageChange {
         self.new_value.is_zero()
     }
 
-    /// Returns true if this change was made by the given transaction.
+    /// Returns true if this change is recorded at the given block access index.
     #[inline]
-    pub const fn is_from_tx(&self, block_index: BlockAccessIndex) -> bool {
+    pub fn is_at_index(&self, block_index: BlockAccessIndex) -> bool {
         self.block_access_index == block_index
     }
 


### PR DESCRIPTION
This is subtle difference between the transaction index and the block access index. However, the both types are represented by essentially the same type.

This commit introduces a new type to avoid potential type confusion and making the distinction more explicit.

A couple of notes:

1. I deliberately did not provide From implementations to serve as a speed bump. The cost of that the tests became a little bit more verbose. If that's important I can provide cfg(test)-gated impls.
2. `is_from_tx` seemed like a precisely the trap that this PR tries to avoid. I did not find any users in revm, so I decided to rename it. Stripped `const` as well to use PartialEq.