### PR TITLE
feat(eip7928): add BAL retention constants

### DIFF
--- a/crates/eip7928/src/constants.rs
+++ b/crates/eip7928/src/constants.rs
@@ -17,6 +17,15 @@ pub const MAX_CODE_SIZE: usize = 24_576;
 /// Item cost for block access list.
 pub const ITEM_COST: usize = 2000;
 
+const ETHEREUM_MAINNET_SLOTS_PER_EPOCH: u64 = 32;
+
+/// Number of epochs the execution layer must retain block access lists for.
+pub const BAL_RETENTION_PERIOD_EPOCHS: u64 = 3_533;
+
+/// Number of slots corresponding to [`BAL_RETENTION_PERIOD_EPOCHS`].
+pub const BAL_RETENTION_PERIOD_SLOTS: u64 =
+    BAL_RETENTION_PERIOD_EPOCHS * ETHEREUM_MAINNET_SLOTS_PER_EPOCH;
+
 /// Type alias for block index for eip-7928.
 pub type BlockAccessIndex = u64;
 


### PR DESCRIPTION
## Summary

- Add exported EIP-7928 BAL retention period constants in epochs and slots.
- Derive the exact slot count from 3,533 epochs and 32 slots per epoch: 113,056 slots.

## Motivation

EIP-7928 requires execution layer clients to retain block access lists for at least the duration of the weak subjectivity period. Exposing BAL-specific retention constants lets downstream crates avoid local magic numbers or approximate cache sizing values.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p alloy-eip7928`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p alloy-eip7928 --no-deps`
