### PR TITLE
feat(eip7928): derive Hash for all change types

### DIFF
--- a/crates/eip7928/src/account_changes.rs
+++ b/crates/eip7928/src/account_changes.rs
@@ -9,14 +9,14 @@ use alloc::vec::Vec;
 use alloy_primitives::{Address, U256};
 
 /// This struct is used to track the changes across accounts in a block.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "rlp", derive(alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AccountChanges {
-    /// The address of the account whoose changes are stored.
+    /// The address of the account whose changes are stored.
     pub address: Address,
     /// List of slot changes for this account.
     pub storage_changes: Vec<SlotChanges>,

--- a/crates/eip7928/src/balance_change.rs
+++ b/crates/eip7928/src/balance_change.rs
@@ -5,7 +5,7 @@ use crate::BlockAccessIndex;
 use alloy_primitives::U256;
 
 /// This struct is used to track the balance changes of accounts in a block.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "rlp", derive(alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]

--- a/crates/eip7928/src/code_change.rs
+++ b/crates/eip7928/src/code_change.rs
@@ -4,7 +4,7 @@ use crate::BlockAccessIndex;
 use alloy_primitives::Bytes;
 
 /// This struct is used to track the new codes of accounts in a block.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "rlp", derive(alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]

--- a/crates/eip7928/src/nonce_change.rs
+++ b/crates/eip7928/src/nonce_change.rs
@@ -4,7 +4,7 @@
 use crate::BlockAccessIndex;
 
 /// This struct is used to track the new nonce of accounts in a block.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "rlp", derive(alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]

--- a/crates/eip7928/src/slot_changes.rs
+++ b/crates/eip7928/src/slot_changes.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 use alloy_primitives::U256;
 
 /// Represents all changes made to a single storage slot across multiple transactions.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "rlp", derive(alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]

--- a/crates/eip7928/src/storage_change.rs
+++ b/crates/eip7928/src/storage_change.rs
@@ -5,7 +5,7 @@ use crate::BlockAccessIndex;
 use alloy_primitives::U256;
 
 /// Represents a single storage write operation within a transaction.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "rlp", derive(alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]


### PR DESCRIPTION
## Motivation

Every EIP crate in this repo derives `Hash` on its core types: `AccessListItem` and `AccessList` in eip2930, `Authorization`, `SignedAuthorization`, and `RecoveredAuthorization` in eip7702, and `Head`, `ForkHash`, and `ForkId` in eip2124. The eip7928 change types all derive `Eq`, and all their fields implement `Hash`, but the derive was never added. This prevents downstream consumers from using these types in `HashSet` or `HashMap`.

Also fixes a "whoose" typo in the `AccountChanges` doc comment.

## Solution

Add `Hash` to the derive list for `StorageChange`, `SlotChanges`, `BalanceChange`, `NonceChange`, `CodeChange`, and `AccountChanges`. `BlockAccessIndex` already derives `Hash`. `Bal` is intentionally excluded since its hashing story is domain-specific (`compute_hash()` uses keccak256 of the RLP encoding).

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
