### PR TITLE
ci: remove unused foundry install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
           toolchain: ${{ matrix.rust }}
-      - name: Install Anvil
-        uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1
-        with:
-          version: nightly
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-on-failure: true


### PR DESCRIPTION
## Summary

Remove the Foundry toolchain setup from the CI test matrix.

## Why

The workflow only runs Cargo build and nextest commands after installing the Rust toolchain. The repository does not use Anvil, Forge, or Cast in the CI test path, so the Foundry install adds setup time and an external dependency without affecting coverage.

## Impact

CI now has one fewer toolchain installation step while keeping the same Rust build and test commands.
