### PR TITLE
feat(eip7702): add `secp256k1` feature for ECDSA recovery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,8 @@ rand = "0.8"
 
 # misc
 thiserror = { version = "2.0.0", default-features = false }
+
+# Temporary: patch alloy-primitives to pick up secp256k1 backend support
+# from https://github.com/alloy-rs/core/pull/1104
+[patch.crates-io]
+alloy-primitives = { git = "https://github.com/decofe/core.git", branch = "feat/secp256k1-backend" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,4 +52,3 @@ rand = "0.8"
 
 # misc
 thiserror = { version = "2.0.0", default-features = false }
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ option-if-let-else = "warn"
 redundant-clone = "warn"
 
 [workspace.dependencies]
-alloy-primitives = { version = "1.4", default-features = false }
+alloy-primitives = { version = "1.6", default-features = false }
 alloy-rlp = { version = "0.3", default-features = false }
 once_cell = { version = "1.20", default-features = false, features = ["alloc", "race"] }
 
@@ -53,7 +53,3 @@ rand = "0.8"
 # misc
 thiserror = { version = "2.0.0", default-features = false }
 
-# Temporary: patch alloy-primitives to pick up secp256k1 backend support
-# from https://github.com/alloy-rs/core/pull/1104
-[patch.crates-io]
-alloy-primitives = { git = "https://github.com/decofe/core.git", branch = "feat/secp256k1-backend" }

--- a/crates/eip7702/Cargo.toml
+++ b/crates/eip7702/Cargo.toml
@@ -56,6 +56,7 @@ serde = ["dep:serde", "alloy-primitives/serde"]
 serde-bincode-compat = ["serde_with"]
 arbitrary = ["std", "dep:arbitrary", "dep:rand", "alloy-primitives/arbitrary"]
 k256 = ["alloy-primitives/k256", "dep:k256"]
+secp256k1 = ["alloy-primitives/secp256k1"]
 borsh = [
 	"dep:borsh",
     "alloy-primitives/borsh",

--- a/crates/eip7702/src/auth_list.rs
+++ b/crates/eip7702/src/auth_list.rs
@@ -252,9 +252,12 @@ impl Encodable for SignedAuthorization {
     }
 }
 
-#[cfg(feature = "k256")]
+#[cfg(any(feature = "k256", feature = "secp256k1"))]
 impl SignedAuthorization {
     /// Recover the authority for the authorization.
+    ///
+    /// When both `k256` and `secp256k1` features are enabled, the `secp256k1` backend is
+    /// preferred.
     ///
     /// # Note
     ///
@@ -369,14 +372,14 @@ impl RecoveredAuthorization {
     }
 }
 
-#[cfg(feature = "k256")]
+#[cfg(any(feature = "k256", feature = "secp256k1"))]
 impl From<SignedAuthorization> for RecoveredAuthority {
     fn from(value: SignedAuthorization) -> Self {
         value.into_recovered().authority
     }
 }
 
-#[cfg(feature = "k256")]
+#[cfg(any(feature = "k256", feature = "secp256k1"))]
 impl From<SignedAuthorization> for RecoveredAuthorization {
     fn from(value: SignedAuthorization) -> Self {
         value.into_recovered()

--- a/deny.toml
+++ b/deny.toml
@@ -43,8 +43,6 @@ exceptions = [
     # https://tldrlegal.com/license/creative-commons-cc0-1.0-universal
     { allow = ["CC0-1.0"], name = "tiny-keccak" },
     { allow = ["CC0-1.0"], name = "trezor-client" },
-    { allow = ["CC0-1.0"], name = "secp256k1" },
-    { allow = ["CC0-1.0"], name = "secp256k1-sys" },
     { allow = ["BSD-2-Clause"], name = "zerocopy" },
 ]
 
@@ -61,7 +59,3 @@ license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-
-# Temporary: allow alloy-primitives from the secp256k1 PR branch
-# Remove once alloy-rs/core#1104 is merged and released
-allow-git = ["https://github.com/decofe/core"]

--- a/deny.toml
+++ b/deny.toml
@@ -43,6 +43,8 @@ exceptions = [
     # https://tldrlegal.com/license/creative-commons-cc0-1.0-universal
     { allow = ["CC0-1.0"], name = "tiny-keccak" },
     { allow = ["CC0-1.0"], name = "trezor-client" },
+    { allow = ["CC0-1.0"], name = "secp256k1" },
+    { allow = ["CC0-1.0"], name = "secp256k1-sys" },
     { allow = ["BSD-2-Clause"], name = "zerocopy" },
 ]
 
@@ -59,3 +61,7 @@ license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
+
+# Temporary: allow alloy-primitives from the secp256k1 PR branch
+# Remove once alloy-rs/core#1104 is merged and released
+allow-git = ["https://github.com/decofe/core"]


### PR DESCRIPTION
## Summary

Add an optional `secp256k1` feature to `alloy-eip7702` that uses the `secp256k1` C library bindings (via the [`secp256k1`](https://crates.io/crates/secp256k1) crate) for ECDSA public key recovery instead of the pure-Rust `k256` implementation.

## Details

- **Feature is disabled by default** — no impact on existing users
- **When both `secp256k1` and `k256` are enabled, `secp256k1` is preferred** for recovery operations (`recover_authority`, `into_recovered`, and the `From` impls)
- The `k256` feature continues to work exactly as before when `secp256k1` is not enabled

### Changes

| File | Change |
|------|--------|
| `Cargo.toml` | Add `secp256k1 = { version = "0.31", features = ["recovery", "alloc"] }` as workspace dep |
| `crates/eip7702/Cargo.toml` | Add optional `secp256k1` dep and feature flag |
| `crates/eip7702/src/auth_list.rs` | Add `secp256k1`-backed recovery impl; gate `k256` impl with `not(feature = "secp256k1")`; update `From` impls to `any(k256, secp256k1)` |
| `crates/eip7702/src/error.rs` | Add `Secp256k1(secp256k1::Error)` variant behind feature gate |

### Usage

```toml
# Use secp256k1 C library for faster recovery
alloy-eip7702 = { version = "0.6", features = ["secp256k1"] }

# Use pure-Rust k256 (existing behavior, unchanged)
alloy-eip7702 = { version = "0.6", features = ["k256"] }

# Both enabled — secp256k1 is preferred
alloy-eip7702 = { version = "0.6", features = ["secp256k1", "k256"] }
```

### Tested

- `cargo check` with each feature combo: `secp256k1`, `k256`, both, neither ✅
- `cargo test --all-features` ✅
- `cargo clippy --all-features -- -Dwarnings` ✅
- `cargo build --target wasm32-unknown-unknown` (default features, no secp256k1) ✅