### PR TITLE
ci: allow secp256k1 CC0 licenses

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -41,6 +41,8 @@ exceptions = [
     # CC0 is a permissive license but somewhat unclear status for source code
     # so we prefer to not have dependencies using it
     # https://tldrlegal.com/license/creative-commons-cc0-1.0-universal
+    { allow = ["CC0-1.0"], name = "secp256k1" },
+    { allow = ["CC0-1.0"], name = "secp256k1-sys" },
     { allow = ["CC0-1.0"], name = "tiny-keccak" },
     { allow = ["CC0-1.0"], name = "trezor-client" },
     { allow = ["BSD-2-Clause"], name = "zerocopy" },


### PR DESCRIPTION
The deny job started failing after the EIP-7702 `secp256k1` feature introduced the `secp256k1` and `secp256k1-sys` crates. Both crates are licensed as CC0-1.0, and this repo allows CC0 only through per-crate exceptions.

This adds narrow CC0-1.0 license exceptions for those two crates, matching the existing exception-based policy instead of broadening the global license allowlist.

No advisory allowlist is needed: the failing GitHub job reported `advisories ok` and failed only in the license check.