### PR TITLE
perf: use fixed buffer for authorization signature hash

### DIFF
--- a/crates/eip7702/src/auth_list.rs
+++ b/crates/eip7702/src/auth_list.rs
@@ -1,7 +1,5 @@
 use core::ops::Deref;
 
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
 use alloy_primitives::{Address, B256, Signature, SignatureError, U8, U256, keccak256};
 use alloy_rlp::{
     BufMut, Decodable, Encodable, Header, Result as RlpResult, RlpDecodable, RlpEncodable,
@@ -97,13 +95,14 @@ impl Authorization {
     /// The signature hash is `keccak(MAGIC || rlp([chain_id, address, nonce]))`
     #[inline]
     pub fn signature_hash(&self) -> B256 {
-        use super::constants::MAGIC;
+        let mut buf = [0u8; 66];
+        buf[0] = super::constants::MAGIC;
 
-        let mut buf = Vec::new();
-        buf.put_u8(MAGIC);
-        self.encode(&mut buf);
+        let mut out = &mut buf[1..];
+        self.encode(&mut out);
+        let written = 66 - out.len();
 
-        keccak256(buf)
+        keccak256(&buf[..written])
     }
 
     /// Convert to a signed authorization by adding a signature.
@@ -528,6 +527,7 @@ pub(super) mod serde_bincode_compat {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec::Vec;
     use alloy_primitives::hex;
     use core::str::FromStr;
 


### PR DESCRIPTION
## Summary
- replace the heap-allocated Vec used for EIP-7702 authorization signature hash preimages with a fixed-size stack array
- write MAGIC into the first byte, then RLP-encode the authorization into the remaining buffer

## Tests
- cargo fmt --check
- cargo check -p alloy-eip7702 --features k256
- cargo test -p alloy-eip7702 --features k256,arbitrary

Prompted by: @DaniPopes