### PR TITLE
feat(eip7928): add raw or decoded BAL helper

### DIFF
--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -313,6 +313,7 @@ pub mod bal {
     }
 
     impl PartialEq for RawBal {
+        #[inline]
         fn eq(&self, other: &Self) -> bool {
             self.raw == other.raw
         }
@@ -321,6 +322,7 @@ pub mod bal {
     impl Eq for RawBal {}
 
     impl From<Bytes> for RawBal {
+        #[inline]
         fn from(raw: Bytes) -> Self {
             Self::new(raw)
         }
@@ -328,6 +330,7 @@ pub mod bal {
 
     impl RawBal {
         /// Creates a new [`RawBal`] from raw RLP bytes.
+        #[inline]
         pub const fn new(raw: Bytes) -> Self {
             Self { raw, hash: OnceLock::new() }
         }
@@ -336,6 +339,7 @@ pub mod bal {
         ///
         /// The hash is not checked against the raw bytes. Callers must ensure `hash` is the
         /// keccak256 hash of `raw`.
+        #[inline]
         pub fn new_unchecked(raw: Bytes, hash: B256) -> Self {
             let this = Self::new(raw);
             #[allow(clippy::useless_conversion)]
@@ -344,22 +348,26 @@ pub mod bal {
         }
 
         /// Returns the original raw RLP bytes.
+        #[inline]
         pub const fn as_raw(&self) -> &Bytes {
             &self.raw
         }
 
         /// Consumes this value and returns the raw RLP bytes.
+        #[inline]
         pub fn into_raw(self) -> Bytes {
             self.raw
         }
 
         /// Consumes this value and returns the raw RLP bytes and hash.
+        #[inline]
         pub fn into_parts(self) -> (Bytes, B256) {
             let hash = self.hash();
             (self.raw, hash)
         }
 
         /// Ensures the raw RLP hash matches the expected block access list hash.
+        #[inline]
         pub fn ensure_hash(&self, expected: B256) -> Result<(), BlockAccessListHashMismatch> {
             let computed = self.hash();
             if computed == expected {
@@ -372,6 +380,7 @@ pub mod bal {
         /// Returns the hash of the raw block access list bytes.
         ///
         /// The hash is computed lazily on first call and cached for subsequent calls.
+        #[inline]
         pub fn hash(&self) -> B256 {
             #[allow(clippy::useless_conversion)]
             *self.hash.get_or_init(|| alloy_primitives::keccak256(self.raw.as_ref()).into())
@@ -380,10 +389,12 @@ pub mod bal {
 
     #[cfg(feature = "rlp")]
     impl alloy_rlp::Encodable for RawBal {
+        #[inline]
         fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
             out.put_slice(&self.raw);
         }
 
+        #[inline]
         fn length(&self) -> usize {
             self.raw.len()
         }
@@ -391,6 +402,7 @@ pub mod bal {
 
     #[cfg(feature = "rlp")]
     impl alloy_rlp::Decodable for RawBal {
+        #[inline]
         fn decode(buf: &mut &[u8]) -> Result<Self, alloy_rlp::Error> {
             let original = *buf;
             let header = alloy_rlp::Header::decode(buf)?;
@@ -416,6 +428,7 @@ pub mod bal {
     }
 
     impl<T: PartialEq> PartialEq for DecodedBal<T> {
+        #[inline]
         fn eq(&self, other: &Self) -> bool {
             self.decoded == other.decoded && self.raw == other.raw
         }
@@ -425,6 +438,7 @@ pub mod bal {
 
     impl<T> DecodedBal<T> {
         /// Creates a new [`DecodedBal`] from decoded data and raw bytes.
+        #[inline]
         pub const fn new(decoded: T, raw: Bytes) -> Self {
             Self { decoded, raw: RawBal::new(raw) }
         }
@@ -433,41 +447,49 @@ pub mod bal {
         ///
         /// The hash is not checked against the raw bytes. Callers must ensure `hash` is the
         /// keccak256 hash of `raw`.
+        #[inline]
         pub fn new_unchecked(decoded: T, raw: Bytes, hash: B256) -> Self {
             Self { decoded, raw: RawBal::new_unchecked(raw, hash) }
         }
 
         /// Creates a new [`DecodedBal`] from decoded data and a [`RawBal`].
+        #[inline]
         pub const fn with_raw_bal(decoded: T, raw: RawBal) -> Self {
             Self { decoded, raw }
         }
 
         /// Returns a reference to the decoded block access list.
+        #[inline]
         pub const fn as_bal(&self) -> &T {
             &self.decoded
         }
 
         /// Returns the original raw RLP bytes.
+        #[inline]
         pub const fn as_raw(&self) -> &Bytes {
             self.raw.as_raw()
         }
 
         /// Returns the raw BAL.
+        #[inline]
         pub const fn as_raw_bal(&self) -> &RawBal {
             &self.raw
         }
 
         /// Splits this struct into the decoded BAL and raw bytes.
+        #[inline]
         pub fn split(self) -> (T, Bytes) {
             (self.decoded, self.raw.into_raw())
         }
 
         /// Splits this struct into the decoded BAL and raw BAL.
+        #[inline]
         pub fn split_raw_bal(self) -> (T, RawBal) {
             (self.decoded, self.raw)
         }
 
         /// Splits this struct into the decoded BAL, raw bytes, and hash.
+        #[inline]
         pub fn into_parts(self) -> (T, Bytes, B256) {
             let hash = self.hash();
             let (decoded, raw) = self.split();
@@ -478,6 +500,7 @@ pub mod bal {
         ///
         /// This checks `keccak256(raw_rlp_of_received_bal) == expected` using the cached hash of
         /// the original raw RLP bytes captured at decode time.
+        #[inline]
         pub fn ensure_hash(&self, expected: B256) -> Result<(), BlockAccessListHashMismatch> {
             let computed = self.hash();
             if computed == expected {
@@ -490,11 +513,13 @@ pub mod bal {
         /// Returns the hash of this block access list.
         ///
         /// The hash is computed lazily on first call and cached for subsequent calls.
+        #[inline]
         pub fn hash(&self) -> B256 {
             self.raw.hash()
         }
 
         /// Converts the decoded BAL to the given alternative that is [`From<T>`].
+        #[inline]
         pub fn convert<U>(self) -> DecodedBal<U>
         where
             U: From<T>,
@@ -503,6 +528,7 @@ pub mod bal {
         }
 
         /// Converts the decoded BAL to the given alternative that is [`TryFrom<T>`].
+        #[inline]
         pub fn try_convert<U>(self) -> Result<DecodedBal<U>, U::Error>
         where
             U: TryFrom<T>,
@@ -511,12 +537,14 @@ pub mod bal {
         }
 
         /// Applies the given closure to the decoded BAL.
+        #[inline]
         pub fn map<U>(self, f: impl FnOnce(T) -> U) -> DecodedBal<U> {
             let Self { decoded, raw } = self;
             DecodedBal { decoded: f(decoded), raw }
         }
 
         /// Applies the given fallible closure to the decoded BAL.
+        #[inline]
         pub fn try_map<U, E>(self, f: impl FnOnce(T) -> Result<U, E>) -> Result<DecodedBal<U>, E> {
             let Self { decoded, raw } = self;
             Ok(DecodedBal { decoded: f(decoded)?, raw })
@@ -526,16 +554,19 @@ pub mod bal {
     #[cfg(feature = "rlp")]
     impl DecodedBal {
         /// Creates a new [`DecodedBal`] by decoding from raw RLP bytes.
+        #[inline]
         pub fn from_rlp_bytes(raw: Bytes) -> Result<Self, alloy_rlp::Error> {
             Self::from_rlp_bytes_as(raw)
         }
 
         /// Creates a new [`DecodedBal`] by decoding from raw RLP bytes in a [`RawBal`].
+        #[inline]
         pub fn from_raw_bal(raw: RawBal) -> Result<Self, alloy_rlp::Error> {
             Self::from_raw_bal_as(raw)
         }
 
         /// Creates a new [`DecodedBal`] by decoding from raw RLP bytes into `T`.
+        #[inline]
         pub fn from_rlp_bytes_as<T>(raw: Bytes) -> Result<DecodedBal<T>, alloy_rlp::Error>
         where
             T: alloy_rlp::Decodable,
@@ -544,6 +575,7 @@ pub mod bal {
         }
 
         /// Creates a new [`DecodedBal`] by decoding from raw RLP bytes in a [`RawBal`] into `T`.
+        #[inline]
         pub fn from_raw_bal_as<T>(raw: RawBal) -> Result<DecodedBal<T>, alloy_rlp::Error>
         where
             T: alloy_rlp::Decodable,
@@ -563,11 +595,13 @@ pub mod bal {
         T: alloy_primitives::Sealable,
     {
         /// Returns the decoded BAL as a sealed borrowed value.
+        #[inline]
         pub fn as_sealed_bal(&self) -> alloy_primitives::Sealed<&T> {
             alloy_primitives::Sealable::seal_ref_unchecked(&self.decoded, self.hash())
         }
 
         /// Consumes this struct and returns the decoded BAL together with its hash.
+        #[inline]
         pub fn into_sealed(self) -> alloy_primitives::Sealed<T> {
             let seal = self.hash();
             let (decoded, _) = self.split();
@@ -580,6 +614,7 @@ pub mod bal {
     where
         T: alloy_rlp::Decodable,
     {
+        #[inline]
         fn decode(buf: &mut &[u8]) -> Result<Self, alloy_rlp::Error> {
             let original = *buf;
             let decoded = T::decode(buf)?;
@@ -591,10 +626,12 @@ pub mod bal {
 
     #[cfg(feature = "rlp")]
     impl<T> alloy_rlp::Encodable for DecodedBal<T> {
+        #[inline]
         fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
             alloy_rlp::Encodable::encode(&self.raw, out);
         }
 
+        #[inline]
         fn length(&self) -> usize {
             alloy_rlp::Encodable::length(&self.raw)
         }
@@ -615,18 +652,21 @@ pub mod bal {
     }
 
     impl<T> From<Bytes> for RawOrDecodedBal<T> {
+        #[inline]
         fn from(raw: Bytes) -> Self {
             Self::Raw(RawBal::new(raw))
         }
     }
 
     impl<T> From<RawBal> for RawOrDecodedBal<T> {
+        #[inline]
         fn from(raw: RawBal) -> Self {
             Self::Raw(raw)
         }
     }
 
     impl<T> From<DecodedBal<T>> for RawOrDecodedBal<T> {
+        #[inline]
         fn from(decoded: DecodedBal<T>) -> Self {
             Self::Decoded(decoded)
         }
@@ -634,6 +674,7 @@ pub mod bal {
 
     impl<T> RawOrDecodedBal<T> {
         /// Creates a new [`RawOrDecodedBal`] from raw RLP bytes.
+        #[inline]
         pub const fn raw(raw: Bytes) -> Self {
             Self::Raw(RawBal::new(raw))
         }
@@ -642,31 +683,37 @@ pub mod bal {
         ///
         /// The hash is not checked against the raw bytes. Callers must ensure `hash` is the
         /// keccak256 hash of `raw`.
+        #[inline]
         pub fn raw_unchecked(raw: Bytes, hash: B256) -> Self {
             Self::Raw(RawBal::new_unchecked(raw, hash))
         }
 
         /// Creates a new [`RawOrDecodedBal`] from a [`RawBal`].
+        #[inline]
         pub const fn raw_bal(raw: RawBal) -> Self {
             Self::Raw(raw)
         }
 
         /// Creates a new [`RawOrDecodedBal`] from a decoded BAL.
+        #[inline]
         pub const fn decoded(decoded: DecodedBal<T>) -> Self {
             Self::Decoded(decoded)
         }
 
         /// Returns `true` if this contains raw RLP bytes.
+        #[inline]
         pub const fn is_raw(&self) -> bool {
             matches!(self, Self::Raw(_))
         }
 
         /// Returns `true` if this contains a decoded BAL.
+        #[inline]
         pub const fn is_decoded(&self) -> bool {
             matches!(self, Self::Decoded(_))
         }
 
         /// Returns the raw RLP bytes.
+        #[inline]
         pub const fn as_raw(&self) -> &Bytes {
             match self {
                 Self::Raw(raw) => raw.as_raw(),
@@ -675,6 +722,7 @@ pub mod bal {
         }
 
         /// Returns the raw BAL.
+        #[inline]
         pub const fn as_raw_bal(&self) -> &RawBal {
             match self {
                 Self::Raw(raw) => raw,
@@ -683,6 +731,7 @@ pub mod bal {
         }
 
         /// Returns the decoded BAL if available.
+        #[inline]
         pub const fn as_decoded(&self) -> Option<&DecodedBal<T>> {
             match self {
                 Self::Raw(_) => None,
@@ -691,6 +740,7 @@ pub mod bal {
         }
 
         /// Returns the decoded BAL if available.
+        #[inline]
         pub fn into_decoded(self) -> Option<DecodedBal<T>> {
             match self {
                 Self::Raw(_) => None,
@@ -699,6 +749,7 @@ pub mod bal {
         }
 
         /// Returns the decoded block access list if available.
+        #[inline]
         pub const fn as_bal(&self) -> Option<&T> {
             match self {
                 Self::Raw(_) => None,
@@ -707,6 +758,7 @@ pub mod bal {
         }
 
         /// Consumes this value and returns the raw RLP bytes.
+        #[inline]
         pub fn into_raw(self) -> Bytes {
             match self {
                 Self::Raw(raw) => raw.into_raw(),
@@ -715,6 +767,7 @@ pub mod bal {
         }
 
         /// Consumes this value and returns the raw BAL.
+        #[inline]
         pub fn into_raw_bal(self) -> RawBal {
             match self {
                 Self::Raw(raw) => raw,
@@ -723,6 +776,7 @@ pub mod bal {
         }
 
         /// Splits this value into its decoded BAL, if available, and raw RLP bytes.
+        #[inline]
         pub fn split(self) -> (Option<T>, Bytes) {
             match self {
                 Self::Raw(raw) => (None, raw.into_raw()),
@@ -734,6 +788,7 @@ pub mod bal {
         }
 
         /// Splits this value into its decoded BAL, if available, and raw BAL.
+        #[inline]
         pub fn split_raw_bal(self) -> (Option<T>, RawBal) {
             match self {
                 Self::Raw(raw) => (None, raw),
@@ -745,6 +800,7 @@ pub mod bal {
         }
 
         /// Ensures the raw RLP hash matches the expected block access list hash.
+        #[inline]
         pub fn ensure_hash(&self, expected: B256) -> Result<(), BlockAccessListHashMismatch> {
             let computed = self.hash();
             if computed == expected {
@@ -755,6 +811,7 @@ pub mod bal {
         }
 
         /// Returns the hash of the raw block access list bytes.
+        #[inline]
         pub fn hash(&self) -> B256 {
             match self {
                 Self::Raw(raw) => raw.hash(),
@@ -765,6 +822,7 @@ pub mod bal {
         /// Converts the decoded BAL to the given alternative that is [`From<T>`].
         ///
         /// Raw values stay raw.
+        #[inline]
         pub fn convert<U>(self) -> RawOrDecodedBal<U>
         where
             U: From<T>,
@@ -775,6 +833,7 @@ pub mod bal {
         /// Converts the decoded BAL to the given alternative that is [`TryFrom<T>`].
         ///
         /// Raw values stay raw.
+        #[inline]
         pub fn try_convert<U>(self) -> Result<RawOrDecodedBal<U>, U::Error>
         where
             U: TryFrom<T>,
@@ -783,6 +842,7 @@ pub mod bal {
         }
 
         /// Applies the given closure to the decoded BAL if available.
+        #[inline]
         pub fn map<U>(self, f: impl FnOnce(T) -> U) -> RawOrDecodedBal<U> {
             match self {
                 Self::Raw(raw) => RawOrDecodedBal::Raw(raw),
@@ -791,6 +851,7 @@ pub mod bal {
         }
 
         /// Applies the given fallible closure to the decoded BAL if available.
+        #[inline]
         pub fn try_map<U, E>(
             self,
             f: impl FnOnce(T) -> Result<U, E>,
@@ -808,6 +869,7 @@ pub mod bal {
         T: alloy_rlp::Decodable,
     {
         /// Up-converts raw RLP bytes into a decoded BAL, or returns the existing decoded BAL.
+        #[inline]
         pub fn try_into_decoded(self) -> Result<DecodedBal<T>, alloy_rlp::Error> {
             match self {
                 Self::Raw(raw) => DecodedBal::from_raw_bal_as(raw),
@@ -818,10 +880,12 @@ pub mod bal {
 
     #[cfg(feature = "rlp")]
     impl<T> alloy_rlp::Encodable for RawOrDecodedBal<T> {
+        #[inline]
         fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
             out.put_slice(self.as_raw());
         }
 
+        #[inline]
         fn length(&self) -> usize {
             self.as_raw().len()
         }
@@ -829,6 +893,7 @@ pub mod bal {
 
     #[cfg(feature = "rlp")]
     impl<T> alloy_rlp::Decodable for RawOrDecodedBal<T> {
+        #[inline]
         fn decode(buf: &mut &[u8]) -> Result<Self, alloy_rlp::Error> {
             <RawBal as alloy_rlp::Decodable>::decode(buf).map(Self::Raw)
         }

--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -465,6 +465,200 @@ pub mod bal {
             self.raw.len()
         }
     }
+
+    /// Either raw RLP bytes or a decoded block access list.
+    ///
+    /// This type is useful when callers may receive raw BAL bytes before the BAL needs to be
+    /// decoded, while still allowing decoded values to preserve and re-use their original raw
+    /// bytes.
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    pub enum RawOrDecodedBal<T = Bal> {
+        /// Raw RLP bytes for a block access list.
+        Raw(Bytes),
+        /// A decoded block access list with its original raw RLP bytes.
+        Decoded(DecodedBal<T>),
+    }
+
+    impl<T> From<Bytes> for RawOrDecodedBal<T> {
+        fn from(raw: Bytes) -> Self {
+            Self::Raw(raw)
+        }
+    }
+
+    impl<T> From<DecodedBal<T>> for RawOrDecodedBal<T> {
+        fn from(decoded: DecodedBal<T>) -> Self {
+            Self::Decoded(decoded)
+        }
+    }
+
+    impl<T> RawOrDecodedBal<T> {
+        /// Creates a new [`RawOrDecodedBal`] from raw RLP bytes.
+        pub const fn raw(raw: Bytes) -> Self {
+            Self::Raw(raw)
+        }
+
+        /// Creates a new [`RawOrDecodedBal`] from a decoded BAL.
+        pub const fn decoded(decoded: DecodedBal<T>) -> Self {
+            Self::Decoded(decoded)
+        }
+
+        /// Returns `true` if this contains raw RLP bytes.
+        pub const fn is_raw(&self) -> bool {
+            matches!(self, Self::Raw(_))
+        }
+
+        /// Returns `true` if this contains a decoded BAL.
+        pub const fn is_decoded(&self) -> bool {
+            matches!(self, Self::Decoded(_))
+        }
+
+        /// Returns the raw RLP bytes.
+        pub const fn as_raw(&self) -> &Bytes {
+            match self {
+                Self::Raw(raw) => raw,
+                Self::Decoded(decoded) => decoded.as_raw(),
+            }
+        }
+
+        /// Returns the decoded BAL if available.
+        pub const fn as_decoded(&self) -> Option<&DecodedBal<T>> {
+            match self {
+                Self::Raw(_) => None,
+                Self::Decoded(decoded) => Some(decoded),
+            }
+        }
+
+        /// Returns the decoded BAL if available.
+        pub fn into_decoded(self) -> Option<DecodedBal<T>> {
+            match self {
+                Self::Raw(_) => None,
+                Self::Decoded(decoded) => Some(decoded),
+            }
+        }
+
+        /// Returns the decoded block access list if available.
+        pub const fn as_bal(&self) -> Option<&T> {
+            match self {
+                Self::Raw(_) => None,
+                Self::Decoded(decoded) => Some(decoded.as_bal()),
+            }
+        }
+
+        /// Consumes this value and returns the raw RLP bytes.
+        pub fn into_raw(self) -> Bytes {
+            match self {
+                Self::Raw(raw) => raw,
+                Self::Decoded(decoded) => decoded.split().1,
+            }
+        }
+
+        /// Splits this value into its decoded BAL, if available, and raw RLP bytes.
+        pub fn split(self) -> (Option<T>, Bytes) {
+            match self {
+                Self::Raw(raw) => (None, raw),
+                Self::Decoded(decoded) => {
+                    let (bal, raw) = decoded.split();
+                    (Some(bal), raw)
+                }
+            }
+        }
+
+        /// Ensures the raw RLP hash matches the expected block access list hash.
+        pub fn ensure_hash(&self, expected: B256) -> Result<(), BlockAccessListHashMismatch> {
+            let computed = self.hash();
+            if computed == expected {
+                Ok(())
+            } else {
+                Err(BlockAccessListHashMismatch::new(computed, expected))
+            }
+        }
+
+        /// Returns the hash of the raw block access list bytes.
+        pub fn hash(&self) -> B256 {
+            match self {
+                Self::Raw(raw) => alloy_primitives::keccak256(raw.as_ref()),
+                Self::Decoded(decoded) => decoded.hash(),
+            }
+        }
+
+        /// Converts the decoded BAL to the given alternative that is [`From<T>`].
+        ///
+        /// Raw values stay raw.
+        pub fn convert<U>(self) -> RawOrDecodedBal<U>
+        where
+            U: From<T>,
+        {
+            self.map(U::from)
+        }
+
+        /// Converts the decoded BAL to the given alternative that is [`TryFrom<T>`].
+        ///
+        /// Raw values stay raw.
+        pub fn try_convert<U>(self) -> Result<RawOrDecodedBal<U>, U::Error>
+        where
+            U: TryFrom<T>,
+        {
+            self.try_map(U::try_from)
+        }
+
+        /// Applies the given closure to the decoded BAL if available.
+        pub fn map<U>(self, f: impl FnOnce(T) -> U) -> RawOrDecodedBal<U> {
+            match self {
+                Self::Raw(raw) => RawOrDecodedBal::Raw(raw),
+                Self::Decoded(decoded) => RawOrDecodedBal::Decoded(decoded.map(f)),
+            }
+        }
+
+        /// Applies the given fallible closure to the decoded BAL if available.
+        pub fn try_map<U, E>(
+            self,
+            f: impl FnOnce(T) -> Result<U, E>,
+        ) -> Result<RawOrDecodedBal<U>, E> {
+            match self {
+                Self::Raw(raw) => Ok(RawOrDecodedBal::Raw(raw)),
+                Self::Decoded(decoded) => decoded.try_map(f).map(RawOrDecodedBal::Decoded),
+            }
+        }
+    }
+
+    #[cfg(feature = "rlp")]
+    impl<T> RawOrDecodedBal<T>
+    where
+        T: alloy_rlp::Decodable,
+    {
+        /// Up-converts raw RLP bytes into a decoded BAL, or returns the existing decoded BAL.
+        pub fn try_into_decoded(self) -> Result<DecodedBal<T>, alloy_rlp::Error> {
+            match self {
+                Self::Raw(raw) => DecodedBal::from_rlp_bytes_as(raw),
+                Self::Decoded(decoded) => Ok(decoded),
+            }
+        }
+    }
+
+    #[cfg(feature = "rlp")]
+    impl<T> alloy_rlp::Encodable for RawOrDecodedBal<T> {
+        fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
+            out.put_slice(self.as_raw());
+        }
+
+        fn length(&self) -> usize {
+            self.as_raw().len()
+        }
+    }
+
+    #[cfg(feature = "rlp")]
+    impl<T> alloy_rlp::Decodable for RawOrDecodedBal<T> {
+        fn decode(buf: &mut &[u8]) -> Result<Self, alloy_rlp::Error> {
+            let original = *buf;
+            let header = alloy_rlp::Header::decode(buf)?;
+            let header_len = original.len() - buf.len();
+            let raw_len = header_len + header.payload_length;
+            let raw = Bytes::copy_from_slice(&original[..raw_len]);
+            *buf = &original[raw_len..];
+            Ok(Self::Raw(raw))
+        }
+    }
 }
 
 /// Error returned when a block access list item cost exceeds the block gas limit.
@@ -507,7 +701,7 @@ impl BlockAccessListHashMismatch {
 
 #[cfg(test)]
 mod hash_tests {
-    use super::bal::{Bal, DecodedBal};
+    use super::bal::{Bal, DecodedBal, RawOrDecodedBal};
     use crate::{
         AccountChanges, BalanceChange, BlockAccessIndex, CodeChange, NonceChange, SlotChanges,
         StorageChange, constants::ITEM_COST,
@@ -608,6 +802,75 @@ mod hash_tests {
             decoded.ensure_hash(expected),
             Err(super::BlockAccessListHashMismatch::new(computed, expected))
         );
+    }
+
+    #[test]
+    fn raw_or_decoded_bal_raw_helpers_use_raw_bytes() {
+        let raw = Bytes::from_static(&[0xc0]);
+        let bal = RawOrDecodedBal::<Bal>::raw(raw.clone());
+        let hash = alloy_primitives::keccak256(raw.as_ref());
+
+        assert!(bal.is_raw());
+        assert!(!bal.is_decoded());
+        assert_eq!(bal.as_raw(), &raw);
+        assert_eq!(bal.as_decoded(), None);
+        assert_eq!(bal.as_bal(), None);
+        assert_eq!(bal.hash(), hash);
+        assert_eq!(bal.ensure_hash(hash), Ok(()));
+
+        let (decoded, split_raw) = bal.clone().split();
+        assert_eq!(decoded, None);
+        assert_eq!(split_raw, raw);
+        assert_eq!(bal.into_raw(), raw);
+    }
+
+    #[test]
+    fn raw_or_decoded_bal_decoded_helpers_use_decoded_bal() {
+        let raw = Bytes::from_static(&[0xc0]);
+        let decoded = DecodedBal::new(Bal::default(), raw.clone());
+        let hash = decoded.hash();
+        let bal = RawOrDecodedBal::decoded(decoded.clone());
+
+        assert!(!bal.is_raw());
+        assert!(bal.is_decoded());
+        assert_eq!(bal.as_raw(), &raw);
+        assert_eq!(bal.as_decoded(), Some(&decoded));
+        assert_eq!(bal.as_bal(), Some(decoded.as_bal()));
+        assert_eq!(bal.hash(), hash);
+
+        let (split_bal, split_raw) = bal.clone().split();
+        assert_eq!(split_bal, Some(Bal::default()));
+        assert_eq!(split_raw, raw);
+        assert_eq!(bal.into_decoded(), Some(decoded));
+    }
+
+    #[test]
+    fn raw_or_decoded_bal_convert_maps_only_decoded_values() {
+        let raw = Bytes::from_static(&[0xc0]);
+        let raw_bal: RawOrDecodedBal<Bal> = RawOrDecodedBal::raw(raw.clone());
+        let converted_raw: RawOrDecodedBal<BalLen> = raw_bal.convert();
+
+        assert!(converted_raw.is_raw());
+        assert_eq!(converted_raw.as_raw(), &raw);
+        assert_eq!(converted_raw.as_bal(), None);
+
+        let decoded = DecodedBal::new(Bal::default(), raw.clone());
+        let converted_decoded: RawOrDecodedBal<BalLen> =
+            RawOrDecodedBal::decoded(decoded).convert();
+
+        assert!(converted_decoded.is_decoded());
+        assert_eq!(converted_decoded.as_bal(), Some(&BalLen(0)));
+        assert_eq!(converted_decoded.as_raw(), &raw);
+
+        let err = RawOrDecodedBal::decoded(DecodedBal::new(Bal::default(), raw.clone()))
+            .try_convert::<NonEmptyBal>();
+        assert_eq!(err.unwrap_err(), EmptyBal);
+
+        let raw_result: Result<RawOrDecodedBal<NonEmptyBal>, EmptyBal> =
+            RawOrDecodedBal::<Bal>::raw(raw.clone()).try_convert();
+        let raw_result = raw_result.unwrap();
+        assert!(raw_result.is_raw());
+        assert_eq!(raw_result.as_raw(), &raw);
     }
 
     #[test]
@@ -753,7 +1016,7 @@ mod hash_tests {
 
 #[cfg(all(test, feature = "rlp"))]
 mod tests {
-    use super::bal::{Bal, DecodedBal};
+    use super::bal::{Bal, DecodedBal, RawOrDecodedBal};
     use crate::{
         AccountChanges, BalanceChange, BlockAccessIndex, CodeChange, NonceChange, SlotChanges,
         StorageChange, constants::EMPTY_BLOCK_ACCESS_LIST_HASH,
@@ -850,5 +1113,55 @@ mod tests {
         assert_eq!(decoded.as_bal(), &bal);
         assert_eq!(decoded.as_raw().as_ref(), raw.as_slice());
         assert_eq!(alloy_rlp::encode(&decoded), raw);
+    }
+
+    #[test]
+    fn raw_or_decoded_bal_try_into_decoded_decodes_raw() {
+        let bal = sample_bal();
+        let raw = Bytes::from(alloy_rlp::encode(&bal));
+        let decoded = RawOrDecodedBal::<Bal>::raw(raw.clone()).try_into_decoded().unwrap();
+
+        assert_eq!(decoded.as_bal(), &bal);
+        assert_eq!(decoded.as_raw(), &raw);
+        assert_eq!(decoded.hash(), bal.compute_hash());
+    }
+
+    #[test]
+    fn raw_or_decoded_bal_try_into_decoded_reuses_decoded() {
+        let bal = sample_bal();
+        let raw = Bytes::from(alloy_rlp::encode(&bal));
+        let decoded = DecodedBal::new(bal.clone(), raw.clone());
+        let decoded = RawOrDecodedBal::decoded(decoded).try_into_decoded().unwrap();
+
+        assert_eq!(decoded.as_bal(), &bal);
+        assert_eq!(decoded.as_raw(), &raw);
+        assert_eq!(decoded.hash(), bal.compute_hash());
+    }
+
+    #[test]
+    fn raw_or_decoded_bal_rlp_encodes_raw_bytes() {
+        let bal = sample_bal();
+        let raw = alloy_rlp::encode(&bal);
+        let raw_bal = RawOrDecodedBal::<Bal>::raw(Bytes::from(raw.clone()));
+        let decoded_bal = RawOrDecodedBal::decoded(DecodedBal::new(bal, Bytes::from(raw.clone())));
+
+        assert_eq!(alloy_rlp::encode(&raw_bal), raw);
+        assert_eq!(alloy_rlp::encode(&decoded_bal), raw);
+    }
+
+    #[test]
+    fn raw_or_decoded_bal_decode_preserves_raw_rlp_item() {
+        let bal = sample_bal();
+        let raw = alloy_rlp::encode(&bal);
+        let mut buf = raw.as_ref();
+        let decoded = <RawOrDecodedBal as alloy_rlp::Decodable>::decode(&mut buf).unwrap();
+
+        assert!(buf.is_empty());
+        assert!(decoded.is_raw());
+        assert_eq!(decoded.as_raw().as_ref(), raw.as_slice());
+        assert_eq!(alloy_rlp::encode(&decoded), raw);
+
+        let decoded = decoded.try_into_decoded().unwrap();
+        assert_eq!(decoded.as_bal(), &bal);
     }
 }

--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -300,6 +300,97 @@ pub mod bal {
         pub code: usize,
     }
 
+    /// Raw RLP bytes for a block access list with lazy hash computation.
+    #[derive(Clone, Debug)]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(transparent))]
+    pub struct RawBal {
+        /// The original raw RLP bytes.
+        raw: Bytes,
+        /// Lazily computed hash of the block access list.
+        #[cfg_attr(feature = "serde", serde(skip, default))]
+        hash: OnceLock<B256>,
+    }
+
+    impl PartialEq for RawBal {
+        fn eq(&self, other: &Self) -> bool {
+            self.raw == other.raw
+        }
+    }
+
+    impl Eq for RawBal {}
+
+    impl From<Bytes> for RawBal {
+        fn from(raw: Bytes) -> Self {
+            Self::new(raw)
+        }
+    }
+
+    impl RawBal {
+        /// Creates a new [`RawBal`] from raw RLP bytes.
+        pub const fn new(raw: Bytes) -> Self {
+            Self { raw, hash: OnceLock::new() }
+        }
+
+        /// Returns the original raw RLP bytes.
+        pub const fn as_raw(&self) -> &Bytes {
+            &self.raw
+        }
+
+        /// Consumes this value and returns the raw RLP bytes.
+        pub fn into_raw(self) -> Bytes {
+            self.raw
+        }
+
+        /// Consumes this value and returns the raw RLP bytes and hash.
+        pub fn into_parts(self) -> (Bytes, B256) {
+            let hash = self.hash();
+            (self.raw, hash)
+        }
+
+        /// Ensures the raw RLP hash matches the expected block access list hash.
+        pub fn ensure_hash(&self, expected: B256) -> Result<(), BlockAccessListHashMismatch> {
+            let computed = self.hash();
+            if computed == expected {
+                Ok(())
+            } else {
+                Err(BlockAccessListHashMismatch::new(computed, expected))
+            }
+        }
+
+        /// Returns the hash of the raw block access list bytes.
+        ///
+        /// The hash is computed lazily on first call and cached for subsequent calls.
+        pub fn hash(&self) -> B256 {
+            #[allow(clippy::useless_conversion)]
+            *self.hash.get_or_init(|| alloy_primitives::keccak256(self.raw.as_ref()).into())
+        }
+    }
+
+    #[cfg(feature = "rlp")]
+    impl alloy_rlp::Encodable for RawBal {
+        fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
+            out.put_slice(&self.raw);
+        }
+
+        fn length(&self) -> usize {
+            self.raw.len()
+        }
+    }
+
+    #[cfg(feature = "rlp")]
+    impl alloy_rlp::Decodable for RawBal {
+        fn decode(buf: &mut &[u8]) -> Result<Self, alloy_rlp::Error> {
+            let original = *buf;
+            let header = alloy_rlp::Header::decode(buf)?;
+            let header_len = original.len() - buf.len();
+            let raw_len = header_len + header.payload_length;
+            let raw = Bytes::copy_from_slice(&original[..raw_len]);
+            *buf = &original[raw_len..];
+            Ok(Self::new(raw))
+        }
+    }
+
     /// A decoded block access list with lazy hash computation.
     ///
     /// This type wraps a decoded block access list along with the original raw RLP bytes,
@@ -309,11 +400,8 @@ pub mod bal {
     pub struct DecodedBal<T = Bal> {
         /// The decoded block access list.
         decoded: T,
-        /// The original raw RLP bytes.
-        raw: Bytes,
-        /// Lazily computed hash of the block access list.
-        #[cfg_attr(feature = "serde", serde(skip, default))]
-        hash: OnceLock<B256>,
+        /// Raw RLP bytes and lazily computed hash of the block access list.
+        raw: RawBal,
     }
 
     impl<T: PartialEq> PartialEq for DecodedBal<T> {
@@ -327,7 +415,12 @@ pub mod bal {
     impl<T> DecodedBal<T> {
         /// Creates a new [`DecodedBal`] from decoded data and raw bytes.
         pub const fn new(decoded: T, raw: Bytes) -> Self {
-            Self { decoded, raw, hash: OnceLock::new() }
+            Self { decoded, raw: RawBal::new(raw) }
+        }
+
+        /// Creates a new [`DecodedBal`] from decoded data and a [`RawBal`].
+        pub const fn with_raw_bal(decoded: T, raw: RawBal) -> Self {
+            Self { decoded, raw }
         }
 
         /// Returns a reference to the decoded block access list.
@@ -337,11 +430,21 @@ pub mod bal {
 
         /// Returns the original raw RLP bytes.
         pub const fn as_raw(&self) -> &Bytes {
+            self.raw.as_raw()
+        }
+
+        /// Returns the raw BAL.
+        pub const fn as_raw_bal(&self) -> &RawBal {
             &self.raw
         }
 
         /// Splits this struct into the decoded BAL and raw bytes.
         pub fn split(self) -> (T, Bytes) {
+            (self.decoded, self.raw.into_raw())
+        }
+
+        /// Splits this struct into the decoded BAL and raw BAL.
+        pub fn split_raw_bal(self) -> (T, RawBal) {
             (self.decoded, self.raw)
         }
 
@@ -369,8 +472,7 @@ pub mod bal {
         ///
         /// The hash is computed lazily on first call and cached for subsequent calls.
         pub fn hash(&self) -> B256 {
-            #[allow(clippy::useless_conversion)]
-            *self.hash.get_or_init(|| alloy_primitives::keccak256(self.raw.as_ref()).into())
+            self.raw.hash()
         }
 
         /// Converts the decoded BAL to the given alternative that is [`From<T>`].
@@ -391,14 +493,14 @@ pub mod bal {
 
         /// Applies the given closure to the decoded BAL.
         pub fn map<U>(self, f: impl FnOnce(T) -> U) -> DecodedBal<U> {
-            let Self { decoded, raw, hash } = self;
-            DecodedBal { decoded: f(decoded), raw, hash }
+            let Self { decoded, raw } = self;
+            DecodedBal { decoded: f(decoded), raw }
         }
 
         /// Applies the given fallible closure to the decoded BAL.
         pub fn try_map<U, E>(self, f: impl FnOnce(T) -> Result<U, E>) -> Result<DecodedBal<U>, E> {
-            let Self { decoded, raw, hash } = self;
-            Ok(DecodedBal { decoded: f(decoded)?, raw, hash })
+            let Self { decoded, raw } = self;
+            Ok(DecodedBal { decoded: f(decoded)?, raw })
         }
     }
 
@@ -409,17 +511,30 @@ pub mod bal {
             Self::from_rlp_bytes_as(raw)
         }
 
+        /// Creates a new [`DecodedBal`] by decoding from raw RLP bytes in a [`RawBal`].
+        pub fn from_raw_bal(raw: RawBal) -> Result<Self, alloy_rlp::Error> {
+            Self::from_raw_bal_as(raw)
+        }
+
         /// Creates a new [`DecodedBal`] by decoding from raw RLP bytes into `T`.
         pub fn from_rlp_bytes_as<T>(raw: Bytes) -> Result<DecodedBal<T>, alloy_rlp::Error>
         where
             T: alloy_rlp::Decodable,
         {
-            let mut slice = raw.as_ref();
+            Self::from_raw_bal_as(RawBal::new(raw))
+        }
+
+        /// Creates a new [`DecodedBal`] by decoding from raw RLP bytes in a [`RawBal`] into `T`.
+        pub fn from_raw_bal_as<T>(raw: RawBal) -> Result<DecodedBal<T>, alloy_rlp::Error>
+        where
+            T: alloy_rlp::Decodable,
+        {
+            let mut slice = raw.as_raw().as_ref();
             let decoded = T::decode(&mut slice)?;
             if !slice.is_empty() {
                 return Err(alloy_rlp::Error::UnexpectedLength);
             }
-            Ok(DecodedBal::new(decoded, raw))
+            Ok(DecodedBal::with_raw_bal(decoded, raw))
         }
     }
 
@@ -458,11 +573,11 @@ pub mod bal {
     #[cfg(feature = "rlp")]
     impl<T> alloy_rlp::Encodable for DecodedBal<T> {
         fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
-            out.put_slice(&self.raw);
+            alloy_rlp::Encodable::encode(&self.raw, out);
         }
 
         fn length(&self) -> usize {
-            self.raw.len()
+            alloy_rlp::Encodable::length(&self.raw)
         }
     }
 
@@ -474,14 +589,20 @@ pub mod bal {
     #[derive(Clone, Debug, PartialEq, Eq)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub enum RawOrDecodedBal<T = Bal> {
-        /// Raw RLP bytes for a block access list.
-        Raw(Bytes),
+        /// Raw RLP bytes for a block access list with lazy hash computation.
+        Raw(RawBal),
         /// A decoded block access list with its original raw RLP bytes.
         Decoded(DecodedBal<T>),
     }
 
     impl<T> From<Bytes> for RawOrDecodedBal<T> {
         fn from(raw: Bytes) -> Self {
+            Self::Raw(RawBal::new(raw))
+        }
+    }
+
+    impl<T> From<RawBal> for RawOrDecodedBal<T> {
+        fn from(raw: RawBal) -> Self {
             Self::Raw(raw)
         }
     }
@@ -495,6 +616,11 @@ pub mod bal {
     impl<T> RawOrDecodedBal<T> {
         /// Creates a new [`RawOrDecodedBal`] from raw RLP bytes.
         pub const fn raw(raw: Bytes) -> Self {
+            Self::Raw(RawBal::new(raw))
+        }
+
+        /// Creates a new [`RawOrDecodedBal`] from a [`RawBal`].
+        pub const fn raw_bal(raw: RawBal) -> Self {
             Self::Raw(raw)
         }
 
@@ -516,8 +642,16 @@ pub mod bal {
         /// Returns the raw RLP bytes.
         pub const fn as_raw(&self) -> &Bytes {
             match self {
-                Self::Raw(raw) => raw,
+                Self::Raw(raw) => raw.as_raw(),
                 Self::Decoded(decoded) => decoded.as_raw(),
+            }
+        }
+
+        /// Returns the raw BAL.
+        pub const fn as_raw_bal(&self) -> &RawBal {
+            match self {
+                Self::Raw(raw) => raw,
+                Self::Decoded(decoded) => decoded.as_raw_bal(),
             }
         }
 
@@ -548,17 +682,36 @@ pub mod bal {
         /// Consumes this value and returns the raw RLP bytes.
         pub fn into_raw(self) -> Bytes {
             match self {
-                Self::Raw(raw) => raw,
+                Self::Raw(raw) => raw.into_raw(),
                 Self::Decoded(decoded) => decoded.split().1,
+            }
+        }
+
+        /// Consumes this value and returns the raw BAL.
+        pub fn into_raw_bal(self) -> RawBal {
+            match self {
+                Self::Raw(raw) => raw,
+                Self::Decoded(decoded) => decoded.split_raw_bal().1,
             }
         }
 
         /// Splits this value into its decoded BAL, if available, and raw RLP bytes.
         pub fn split(self) -> (Option<T>, Bytes) {
             match self {
-                Self::Raw(raw) => (None, raw),
+                Self::Raw(raw) => (None, raw.into_raw()),
                 Self::Decoded(decoded) => {
                     let (bal, raw) = decoded.split();
+                    (Some(bal), raw)
+                }
+            }
+        }
+
+        /// Splits this value into its decoded BAL, if available, and raw BAL.
+        pub fn split_raw_bal(self) -> (Option<T>, RawBal) {
+            match self {
+                Self::Raw(raw) => (None, raw),
+                Self::Decoded(decoded) => {
+                    let (bal, raw) = decoded.split_raw_bal();
                     (Some(bal), raw)
                 }
             }
@@ -577,7 +730,7 @@ pub mod bal {
         /// Returns the hash of the raw block access list bytes.
         pub fn hash(&self) -> B256 {
             match self {
-                Self::Raw(raw) => alloy_primitives::keccak256(raw.as_ref()),
+                Self::Raw(raw) => raw.hash(),
                 Self::Decoded(decoded) => decoded.hash(),
             }
         }
@@ -630,7 +783,7 @@ pub mod bal {
         /// Up-converts raw RLP bytes into a decoded BAL, or returns the existing decoded BAL.
         pub fn try_into_decoded(self) -> Result<DecodedBal<T>, alloy_rlp::Error> {
             match self {
-                Self::Raw(raw) => DecodedBal::from_rlp_bytes_as(raw),
+                Self::Raw(raw) => DecodedBal::from_raw_bal_as(raw),
                 Self::Decoded(decoded) => Ok(decoded),
             }
         }
@@ -650,13 +803,7 @@ pub mod bal {
     #[cfg(feature = "rlp")]
     impl<T> alloy_rlp::Decodable for RawOrDecodedBal<T> {
         fn decode(buf: &mut &[u8]) -> Result<Self, alloy_rlp::Error> {
-            let original = *buf;
-            let header = alloy_rlp::Header::decode(buf)?;
-            let header_len = original.len() - buf.len();
-            let raw_len = header_len + header.payload_length;
-            let raw = Bytes::copy_from_slice(&original[..raw_len]);
-            *buf = &original[raw_len..];
-            Ok(Self::Raw(raw))
+            <RawBal as alloy_rlp::Decodable>::decode(buf).map(Self::Raw)
         }
     }
 }
@@ -701,7 +848,7 @@ impl BlockAccessListHashMismatch {
 
 #[cfg(test)]
 mod hash_tests {
-    use super::bal::{Bal, DecodedBal, RawOrDecodedBal};
+    use super::bal::{Bal, DecodedBal, RawBal, RawOrDecodedBal};
     use crate::{
         AccountChanges, BalanceChange, BlockAccessIndex, CodeChange, NonceChange, SlotChanges,
         StorageChange, constants::ITEM_COST,
@@ -805,6 +952,56 @@ mod hash_tests {
     }
 
     #[test]
+    fn raw_bal_hash_uses_raw_bytes() {
+        let raw = Bytes::from_static(&[0xc0]);
+        let raw_bal = RawBal::new(raw.clone());
+        let computed = alloy_primitives::keccak256(raw.as_ref());
+        let expected = B256::from([0x11; 32]);
+
+        assert_eq!(raw_bal.as_raw(), &raw);
+        assert_eq!(raw_bal.hash(), computed);
+        assert_eq!(raw_bal.ensure_hash(computed), Ok(()));
+        assert_eq!(
+            raw_bal.ensure_hash(expected),
+            Err(super::BlockAccessListHashMismatch::new(computed, expected))
+        );
+
+        let (split_raw, split_hash) = raw_bal.into_parts();
+        assert_eq!(split_raw, raw);
+        assert_eq!(split_hash, computed);
+    }
+
+    #[test]
+    fn decoded_bal_exposes_raw_bal() {
+        let raw = Bytes::from_static(&[0xc0]);
+        let raw_bal = RawBal::new(raw.clone());
+        let decoded = DecodedBal::with_raw_bal(Bal::default(), raw_bal.clone());
+
+        assert_eq!(decoded.as_raw_bal(), &raw_bal);
+        assert_eq!(decoded.as_raw(), &raw);
+
+        let (bal, split_raw_bal) = decoded.split_raw_bal();
+        assert!(bal.is_empty());
+        assert_eq!(split_raw_bal, raw_bal);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn decoded_bal_serde_keeps_raw_bytes_field() {
+        let raw = Bytes::from_static(&[0xc0]);
+        let decoded = DecodedBal::new(Bal::default(), raw.clone());
+        let value = serde_json::to_value(&decoded).unwrap();
+
+        assert!(value.get("decoded").is_some());
+        assert_eq!(value.get("raw"), Some(&serde_json::to_value(&raw).unwrap()));
+        assert!(value.get("hash").is_none());
+
+        let decoded = serde_json::from_value::<DecodedBal>(value).unwrap();
+        assert_eq!(decoded.as_bal(), &Bal::default());
+        assert_eq!(decoded.as_raw(), &raw);
+    }
+
+    #[test]
     fn raw_or_decoded_bal_raw_helpers_use_raw_bytes() {
         let raw = Bytes::from_static(&[0xc0]);
         let bal = RawOrDecodedBal::<Bal>::raw(raw.clone());
@@ -813,6 +1010,7 @@ mod hash_tests {
         assert!(bal.is_raw());
         assert!(!bal.is_decoded());
         assert_eq!(bal.as_raw(), &raw);
+        assert_eq!(bal.as_raw_bal().as_raw(), &raw);
         assert_eq!(bal.as_decoded(), None);
         assert_eq!(bal.as_bal(), None);
         assert_eq!(bal.hash(), hash);
@@ -821,6 +1019,10 @@ mod hash_tests {
         let (decoded, split_raw) = bal.clone().split();
         assert_eq!(decoded, None);
         assert_eq!(split_raw, raw);
+        let (decoded, split_raw_bal) = bal.clone().split_raw_bal();
+        assert_eq!(decoded, None);
+        assert_eq!(split_raw_bal.as_raw(), &raw);
+        assert_eq!(bal.clone().into_raw_bal().as_raw(), &raw);
         assert_eq!(bal.into_raw(), raw);
     }
 
@@ -834,6 +1036,7 @@ mod hash_tests {
         assert!(!bal.is_raw());
         assert!(bal.is_decoded());
         assert_eq!(bal.as_raw(), &raw);
+        assert_eq!(bal.as_raw_bal(), decoded.as_raw_bal());
         assert_eq!(bal.as_decoded(), Some(&decoded));
         assert_eq!(bal.as_bal(), Some(decoded.as_bal()));
         assert_eq!(bal.hash(), hash);
@@ -841,6 +1044,9 @@ mod hash_tests {
         let (split_bal, split_raw) = bal.clone().split();
         assert_eq!(split_bal, Some(Bal::default()));
         assert_eq!(split_raw, raw);
+        let (split_bal, split_raw_bal) = bal.clone().split_raw_bal();
+        assert_eq!(split_bal, Some(Bal::default()));
+        assert_eq!(split_raw_bal.as_raw(), &raw);
         assert_eq!(bal.into_decoded(), Some(decoded));
     }
 
@@ -1016,7 +1222,7 @@ mod hash_tests {
 
 #[cfg(all(test, feature = "rlp"))]
 mod tests {
-    use super::bal::{Bal, DecodedBal, RawOrDecodedBal};
+    use super::bal::{Bal, DecodedBal, RawBal, RawOrDecodedBal};
     use crate::{
         AccountChanges, BalanceChange, BlockAccessIndex, CodeChange, NonceChange, SlotChanges,
         StorageChange, constants::EMPTY_BLOCK_ACCESS_LIST_HASH,
@@ -1113,6 +1319,19 @@ mod tests {
         assert_eq!(decoded.as_bal(), &bal);
         assert_eq!(decoded.as_raw().as_ref(), raw.as_slice());
         assert_eq!(alloy_rlp::encode(&decoded), raw);
+    }
+
+    #[test]
+    fn raw_bal_rlp_roundtrip_preserves_raw_item() {
+        let bal = sample_bal();
+        let raw = alloy_rlp::encode(&bal);
+        let mut buf = raw.as_ref();
+        let raw_bal = <RawBal as alloy_rlp::Decodable>::decode(&mut buf).unwrap();
+
+        assert!(buf.is_empty());
+        assert_eq!(raw_bal.as_raw().as_ref(), raw.as_slice());
+        assert_eq!(alloy_rlp::encode(&raw_bal), raw);
+        assert_eq!(raw_bal.hash(), bal.compute_hash());
     }
 
     #[test]

--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -332,6 +332,17 @@ pub mod bal {
             Self { raw, hash: OnceLock::new() }
         }
 
+        /// Creates a new [`RawBal`] from raw RLP bytes and a precomputed hash.
+        ///
+        /// The hash is not checked against the raw bytes. Callers must ensure `hash` is the
+        /// keccak256 hash of `raw`.
+        pub fn new_unchecked(raw: Bytes, hash: B256) -> Self {
+            let this = Self::new(raw);
+            #[allow(clippy::useless_conversion)]
+            let _ = this.hash.get_or_init(|| hash.into());
+            this
+        }
+
         /// Returns the original raw RLP bytes.
         pub const fn as_raw(&self) -> &Bytes {
             &self.raw
@@ -416,6 +427,14 @@ pub mod bal {
         /// Creates a new [`DecodedBal`] from decoded data and raw bytes.
         pub const fn new(decoded: T, raw: Bytes) -> Self {
             Self { decoded, raw: RawBal::new(raw) }
+        }
+
+        /// Creates a new [`DecodedBal`] from decoded data, raw bytes, and a precomputed hash.
+        ///
+        /// The hash is not checked against the raw bytes. Callers must ensure `hash` is the
+        /// keccak256 hash of `raw`.
+        pub fn new_unchecked(decoded: T, raw: Bytes, hash: B256) -> Self {
+            Self { decoded, raw: RawBal::new_unchecked(raw, hash) }
         }
 
         /// Creates a new [`DecodedBal`] from decoded data and a [`RawBal`].
@@ -617,6 +636,14 @@ pub mod bal {
         /// Creates a new [`RawOrDecodedBal`] from raw RLP bytes.
         pub const fn raw(raw: Bytes) -> Self {
             Self::Raw(RawBal::new(raw))
+        }
+
+        /// Creates a new [`RawOrDecodedBal`] from raw RLP bytes and a precomputed hash.
+        ///
+        /// The hash is not checked against the raw bytes. Callers must ensure `hash` is the
+        /// keccak256 hash of `raw`.
+        pub fn raw_unchecked(raw: Bytes, hash: B256) -> Self {
+            Self::Raw(RawBal::new_unchecked(raw, hash))
         }
 
         /// Creates a new [`RawOrDecodedBal`] from a [`RawBal`].
@@ -972,6 +999,21 @@ mod hash_tests {
     }
 
     #[test]
+    fn raw_bal_new_unchecked_uses_supplied_hash() {
+        let raw = Bytes::from_static(&[0xc0]);
+        let hash = B256::from([0x11; 32]);
+        let raw_bal = RawBal::new_unchecked(raw.clone(), hash);
+
+        assert_eq!(raw_bal.as_raw(), &raw);
+        assert_eq!(raw_bal.hash(), hash);
+        assert_eq!(raw_bal.ensure_hash(hash), Ok(()));
+
+        let (split_raw, split_hash) = raw_bal.into_parts();
+        assert_eq!(split_raw, raw);
+        assert_eq!(split_hash, hash);
+    }
+
+    #[test]
     fn decoded_bal_exposes_raw_bal() {
         let raw = Bytes::from_static(&[0xc0]);
         let raw_bal = RawBal::new(raw.clone());
@@ -983,6 +1025,17 @@ mod hash_tests {
         let (bal, split_raw_bal) = decoded.split_raw_bal();
         assert!(bal.is_empty());
         assert_eq!(split_raw_bal, raw_bal);
+    }
+
+    #[test]
+    fn decoded_bal_new_unchecked_uses_supplied_hash() {
+        let raw = Bytes::from_static(&[0xc0]);
+        let hash = B256::from([0x11; 32]);
+        let decoded = DecodedBal::new_unchecked(Bal::default(), raw.clone(), hash);
+
+        assert_eq!(decoded.as_raw(), &raw);
+        assert_eq!(decoded.hash(), hash);
+        assert_eq!(decoded.ensure_hash(hash), Ok(()));
     }
 
     #[cfg(feature = "serde")]
@@ -1024,6 +1077,18 @@ mod hash_tests {
         assert_eq!(split_raw_bal.as_raw(), &raw);
         assert_eq!(bal.clone().into_raw_bal().as_raw(), &raw);
         assert_eq!(bal.into_raw(), raw);
+    }
+
+    #[test]
+    fn raw_or_decoded_bal_raw_unchecked_uses_supplied_hash() {
+        let raw = Bytes::from_static(&[0xc0]);
+        let hash = B256::from([0x11; 32]);
+        let bal = RawOrDecodedBal::<Bal>::raw_unchecked(raw.clone(), hash);
+
+        assert!(bal.is_raw());
+        assert_eq!(bal.as_raw(), &raw);
+        assert_eq!(bal.hash(), hash);
+        assert_eq!(bal.ensure_hash(hash), Ok(()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `RawBal` to the EIP-7928 BAL module as a raw RLP byte wrapper with lazy hash caching, then uses it as the shared raw representation for `DecodedBal<T>` and `RawOrDecodedBal<T>`.

`DecodedBal<T>` keeps its existing byte-based constructor and accessors while also exposing `RawBal` helpers. `RawOrDecodedBal<T>` now stores `Raw(RawBal)` and still supports constructing from `Bytes`, raw/hash access, decoded BAL mapping/conversion helpers, and raw-to-decoded up-conversion when the `rlp` feature is enabled.

The raw wrappers also support pre-seeding a known hash through unchecked constructors: `RawBal::new_unchecked`, `DecodedBal::new_unchecked`, and `RawOrDecodedBal::raw_unchecked`.

## Impact

Downstream code can pass BAL data around without choosing between raw bytes and decoded state upfront, decode only when needed, and retain or supply a cached hash alongside the original encoded BAL bytes.