### PR TITLE
fix: quote dependabot schedule time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: "07:00"
+      time: "09:00"
       timezone: UTC
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 09:00
+      time: "07:00"
       timezone: UTC
     cooldown:
       default-days: 7


### PR DESCRIPTION
## Summary
- quote Dependabot `schedule.time` so GitHub parses it as a string
- set the fixed weekly run time to Monday at 07:00 UTC

## Testing
- checked `.github/dependabot.yml` contains quoted `time: "07:00"` entries