### PR TITLE
perf(eip7928): speed up BAL hash encoding

### DIFF
--- a/crates/eip7928/Cargo.toml
+++ b/crates/eip7928/Cargo.toml
@@ -42,7 +42,13 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 rand = { workspace = true, optional = true }
 
 [dev-dependencies]
+criterion = "0.8.2"
 serde_json.workspace = true
+
+[[bench]]
+name = "bal_hash"
+harness = false
+required-features = ["rlp"]
 
 
 [features]

--- a/crates/eip7928/benches/bal_hash.rs
+++ b/crates/eip7928/benches/bal_hash.rs
@@ -1,0 +1,127 @@
+//! Benchmarks for block access list hash computation.
+
+use alloy_eip7928::{
+    AccountChanges, BalanceChange, BlockAccessIndex, CodeChange, NonceChange, SlotChanges,
+    StorageChange, compute_block_access_list_hash,
+};
+use alloy_primitives::{Address, Bytes, U256};
+use alloy_rlp::Encodable;
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
+
+fn baseline_compute_block_access_list_hash(bal: &[AccountChanges]) -> alloy_primitives::B256 {
+    let mut buf = Vec::new();
+    alloy_rlp::encode_list(bal, &mut buf);
+    alloy_primitives::keccak256(&buf)
+}
+
+fn address(index: usize) -> Address {
+    let mut bytes = [0; 20];
+    bytes[12..].copy_from_slice(&(index as u64).to_be_bytes());
+    Address::from(bytes)
+}
+
+fn value(account: usize, item: usize) -> U256 {
+    U256::from(((account as u64) << 32) | item as u64)
+}
+
+const fn block_access_index(account: usize, item: usize) -> BlockAccessIndex {
+    BlockAccessIndex::new((account as u64).wrapping_mul(31).wrapping_add(item as u64))
+}
+
+fn make_bal(
+    accounts: usize,
+    storage_changes_per_account: usize,
+    storage_reads_per_account: usize,
+    balance_changes_per_account: usize,
+    nonce_changes_per_account: usize,
+    code_changes_per_account: usize,
+) -> Vec<AccountChanges> {
+    let mut bal = Vec::with_capacity(accounts);
+
+    for account_index in 0..accounts {
+        let mut account = AccountChanges::with_capacity(
+            address(account_index),
+            storage_changes_per_account
+                .max(storage_reads_per_account)
+                .max(balance_changes_per_account)
+                .max(nonce_changes_per_account)
+                .max(code_changes_per_account),
+        );
+
+        for slot_index in 0..storage_changes_per_account {
+            account.storage_changes.push(SlotChanges::new(
+                value(account_index, slot_index),
+                vec![StorageChange::new(
+                    block_access_index(account_index, slot_index),
+                    value(account_index, slot_index + 1),
+                )],
+            ));
+        }
+
+        for read_index in 0..storage_reads_per_account {
+            account.storage_reads.push(value(account_index, read_index + 128));
+        }
+
+        for balance_index in 0..balance_changes_per_account {
+            account.balance_changes.push(BalanceChange::new(
+                block_access_index(account_index, balance_index + 256),
+                value(account_index, balance_index + 257),
+            ));
+        }
+
+        for nonce_index in 0..nonce_changes_per_account {
+            account.nonce_changes.push(NonceChange::new(
+                block_access_index(account_index, nonce_index + 384),
+                nonce_index as u64,
+            ));
+        }
+
+        for code_index in 0..code_changes_per_account {
+            account.code_changes.push(CodeChange::new(
+                block_access_index(account_index, code_index + 512),
+                Bytes::copy_from_slice(&[0x60, code_index as u8, 0x5f, 0x55]),
+            ));
+        }
+
+        bal.push(account);
+    }
+
+    bal
+}
+
+fn encoded_len(bal: &[AccountChanges]) -> usize {
+    let payload_length = bal.iter().map(Encodable::length).sum();
+    payload_length + alloy_rlp::length_of_length(payload_length)
+}
+
+fn bench_hash(c: &mut Criterion) {
+    let cases = [
+        ("empty", Vec::new()),
+        ("tiny", make_bal(1, 1, 1, 1, 1, 0)),
+        ("regular_rpc_shape", make_bal(188, 1, 1, 1, 1, 0)),
+        ("large_storage_heavy", make_bal(2_048, 8, 4, 2, 1, 0)),
+        ("large_code_heavy", make_bal(512, 2, 2, 1, 1, 1)),
+    ];
+
+    let mut group = c.benchmark_group("compute_block_access_list_hash");
+    for (name, bal) in &cases {
+        assert_eq!(
+            compute_block_access_list_hash(bal),
+            baseline_compute_block_access_list_hash(bal)
+        );
+        group.throughput(Throughput::Bytes(encoded_len(bal) as u64));
+
+        group.bench_with_input(BenchmarkId::new("baseline", name), bal, |b, bal| {
+            b.iter(|| baseline_compute_block_access_list_hash(black_box(bal)));
+        });
+
+        group.bench_with_input(BenchmarkId::new("optimized", name), bal, |b, bal| {
+            b.iter(|| compute_block_access_list_hash(black_box(bal)));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_hash);
+criterion_main!(benches);

--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -11,12 +11,90 @@ use std::sync::OnceLock;
 /// This struct is used to store `account_changes` in a block.
 pub type BlockAccessList = Vec<AccountChanges>;
 
+// Below this, the side-vector allocation costs more than reusing account payload lengths.
+#[cfg(feature = "rlp")]
+const ACCOUNT_PAYLOAD_LENGTH_CACHE_THRESHOLD: usize = 16;
+
 /// Computes the hash of the given block access list.
 #[cfg(feature = "rlp")]
 pub fn compute_block_access_list_hash(bal: &[AccountChanges]) -> alloy_primitives::B256 {
-    let mut buf = Vec::new();
-    alloy_rlp::encode_list(bal, &mut buf);
+    if bal.is_empty() {
+        return crate::constants::EMPTY_BLOCK_ACCESS_LIST_HASH;
+    }
+
+    if bal.len() < ACCOUNT_PAYLOAD_LENGTH_CACHE_THRESHOLD {
+        return compute_block_access_list_hash_without_cached_account_lengths(bal);
+    }
+
+    use alloy_rlp::Encodable;
+
+    let mut account_payload_lengths = Vec::with_capacity(bal.len());
+    let mut payload_length = 0;
+    for account in bal {
+        let account_payload_length = account_changes_payload_length(account);
+        payload_length += rlp_payload_length(account_payload_length);
+        account_payload_lengths.push(account_payload_length);
+    }
+
+    let mut buf = Vec::with_capacity(payload_length + alloy_rlp::length_of_length(payload_length));
+
+    alloy_rlp::Header { list: true, payload_length }.encode(&mut buf);
+    for (account, account_payload_length) in bal.iter().zip(account_payload_lengths) {
+        alloy_rlp::Header { list: true, payload_length: account_payload_length }.encode(&mut buf);
+        account.address.encode(&mut buf);
+        alloy_rlp::encode_list(&account.storage_changes, &mut buf);
+        alloy_rlp::encode_list(&account.storage_reads, &mut buf);
+        alloy_rlp::encode_list(&account.balance_changes, &mut buf);
+        alloy_rlp::encode_list(&account.nonce_changes, &mut buf);
+        alloy_rlp::encode_list(&account.code_changes, &mut buf);
+    }
+
+    debug_assert_eq!(buf.len(), payload_length + alloy_rlp::length_of_length(payload_length));
     alloy_primitives::keccak256(&buf)
+}
+
+#[cfg(feature = "rlp")]
+#[inline]
+fn compute_block_access_list_hash_without_cached_account_lengths(
+    bal: &[AccountChanges],
+) -> alloy_primitives::B256 {
+    use alloy_rlp::Encodable;
+
+    let payload_length = bal.iter().map(Encodable::length).sum();
+    let mut buf = Vec::with_capacity(rlp_payload_length(payload_length));
+
+    alloy_rlp::Header { list: true, payload_length }.encode(&mut buf);
+    for account in bal {
+        account.encode(&mut buf);
+    }
+
+    debug_assert_eq!(buf.len(), rlp_payload_length(payload_length));
+    alloy_primitives::keccak256(&buf)
+}
+
+#[cfg(feature = "rlp")]
+#[inline]
+fn account_changes_payload_length(account: &AccountChanges) -> usize {
+    use alloy_rlp::Encodable;
+
+    account.address.length()
+        + rlp_list_length(&account.storage_changes)
+        + rlp_list_length(&account.storage_reads)
+        + rlp_list_length(&account.balance_changes)
+        + rlp_list_length(&account.nonce_changes)
+        + rlp_list_length(&account.code_changes)
+}
+
+#[cfg(feature = "rlp")]
+#[inline]
+fn rlp_list_length<T: alloy_rlp::Encodable>(values: &[T]) -> usize {
+    rlp_payload_length(values.iter().map(alloy_rlp::Encodable::length).sum())
+}
+
+#[cfg(feature = "rlp")]
+#[inline]
+const fn rlp_payload_length(payload_length: usize) -> usize {
+    payload_length + alloy_rlp::length_of_length(payload_length)
 }
 
 /// Computes the total number of items in the block access list, counting each account and storage


### PR DESCRIPTION
## Summary
- Fast-path empty block access list hashes with the existing empty BAL hash constant.
- Pre-size the top-level RLP buffer instead of growing from an empty `Vec`.
- Cache account payload lengths for regular and large BALs so account headers can be written without repeating that nested length walk.
- Add a Criterion benchmark for the previous `encode_list` path versus `compute_block_access_list_hash` across empty, tiny, RPC-shaped, and larger synthetic BALs.

## Impact
This keeps the encoded bytes unchanged while reducing work in the decoded-BAL hashing path. On the local Criterion run, the RPC-shaped case modeled after a live `eth_getBlockAccessListByBlockNumber latest` response improved from roughly 27.5 us to 26.5 us, with larger synthetic cases improving by about 6% and small BALs retaining the exact-reserve fast path.

## Root Cause
`compute_block_access_list_hash` encoded into a zero-capacity buffer through `alloy_rlp::encode_list`, leaving allocation growth to `Vec` and causing generated RLP encoders to repeat account-level payload length work while writing headers.