### PR TITLE
feat: add BAL merge helper

### DIFF
--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -35,7 +35,7 @@ pub mod bal {
         diff::BalDiff,
     };
     use alloc::vec::{IntoIter, Vec};
-    use alloy_primitives::{B256, Bytes};
+    use alloy_primitives::{B256, Bytes, map::HashMap};
     use core::{
         ops::{Deref, Index},
         slice::Iter,
@@ -135,6 +135,38 @@ pub mod bal {
         #[inline]
         pub fn push(&mut self, account_changes: AccountChanges) {
             self.0.push(account_changes)
+        }
+
+        /// Merges the provided account changes into this block access list.
+        ///
+        /// Duplicate account entries already present in this BAL or provided by `incoming` are
+        /// folded into the first entry for that account using [`AccountChanges::merge`]. Changes
+        /// for accounts not already present are appended as new entries.
+        ///
+        /// This preserves relative ordering by keeping existing account entries in place and
+        /// appending newly seen accounts. Call [`Self::sort`] after merging if canonical EIP-7928
+        /// ordering is required.
+        pub fn merge<I>(&mut self, incoming: I)
+        where
+            I: IntoIterator<Item = AccountChanges>,
+        {
+            let existing_accounts = core::mem::take(&mut self.0);
+            let mut merged_accounts = Vec::<AccountChanges>::with_capacity(existing_accounts.len());
+            let mut account_positions = HashMap::<_, usize>::with_capacity_and_hasher(
+                existing_accounts.len(),
+                Default::default(),
+            );
+
+            for account_changes in existing_accounts.into_iter().chain(incoming) {
+                if let Some(&idx) = account_positions.get(&account_changes.address) {
+                    merged_accounts[idx].merge(account_changes);
+                } else {
+                    account_positions.insert(account_changes.address, merged_accounts.len());
+                    merged_accounts.push(account_changes);
+                }
+            }
+
+            self.0 = merged_accounts;
         }
 
         /// Returns `true` if the list contains no elements.
@@ -943,6 +975,7 @@ mod hash_tests {
         AccountChanges, BalanceChange, BlockAccessIndex, CodeChange, NonceChange, SlotChanges,
         StorageChange, constants::ITEM_COST,
     };
+    use alloc::vec::Vec;
     use alloy_primitives::{Address, B256, Bytes, U256};
 
     #[test]
@@ -1213,6 +1246,95 @@ mod hash_tests {
         let raw_result = raw_result.unwrap();
         assert!(raw_result.is_raw());
         assert_eq!(raw_result.as_raw(), &raw);
+    }
+
+    #[test]
+    fn bal_merge_combines_duplicate_accounts_and_appends_new_accounts() {
+        let existing_address = Address::from([0x11; 20]);
+        let new_address = Address::from([0x22; 20]);
+        let mut bal = Bal::new(vec![
+            AccountChanges {
+                address: existing_address,
+                storage_changes: vec![SlotChanges::new(
+                    U256::from(1),
+                    vec![StorageChange::new(BlockAccessIndex::new(0), U256::from(10))],
+                )],
+                storage_reads: vec![U256::from(2)],
+                balance_changes: vec![BalanceChange::new(
+                    BlockAccessIndex::new(1),
+                    U256::from(100),
+                )],
+                nonce_changes: vec![],
+                code_changes: vec![],
+            },
+            AccountChanges::new(existing_address).with_code_change(CodeChange::new(
+                BlockAccessIndex::new(5),
+                Bytes::from_static(&[0xbb]),
+            )),
+        ]);
+
+        bal.merge([
+            AccountChanges {
+                address: existing_address,
+                storage_changes: vec![SlotChanges::new(
+                    U256::from(2),
+                    vec![StorageChange::new(BlockAccessIndex::new(2), U256::from(20))],
+                )],
+                storage_reads: vec![U256::from(1), U256::from(3), U256::from(3)],
+                balance_changes: vec![BalanceChange::new(
+                    BlockAccessIndex::new(3),
+                    U256::from(200),
+                )],
+                nonce_changes: vec![],
+                code_changes: vec![],
+            },
+            AccountChanges::new(new_address)
+                .with_nonce_change(NonceChange::new(BlockAccessIndex::new(4), 7)),
+        ]);
+
+        assert_eq!(bal.len(), 2);
+        assert_eq!(bal[0].address, existing_address);
+        assert_eq!(bal[1].address, new_address);
+        assert_eq!(
+            bal[0].storage_changes.iter().map(|changes| changes.slot).collect::<Vec<_>>(),
+            vec![U256::from(1), U256::from(2)]
+        );
+        assert_eq!(bal[0].storage_reads, vec![U256::from(3)]);
+        assert_eq!(
+            bal[0]
+                .balance_changes
+                .iter()
+                .map(|change| change.block_access_index)
+                .collect::<Vec<_>>(),
+            vec![BlockAccessIndex::new(1), BlockAccessIndex::new(3)]
+        );
+        assert_eq!(
+            bal[0].code_changes,
+            vec![CodeChange::new(BlockAccessIndex::new(5), Bytes::from_static(&[0xbb]))]
+        );
+        assert_eq!(bal[1].nonce_changes, vec![NonceChange::new(BlockAccessIndex::new(4), 7)]);
+    }
+
+    #[test]
+    fn bal_merge_collapses_duplicate_accounts_from_incoming_iterator() {
+        let address = Address::from([0x11; 20]);
+        let mut bal = Bal::default();
+
+        bal.merge([
+            AccountChanges::new(address)
+                .with_balance_change(BalanceChange::new(BlockAccessIndex::new(0), U256::from(100))),
+            AccountChanges::new(address).with_code_change(CodeChange::new(
+                BlockAccessIndex::new(1),
+                Bytes::from_static(&[0xaa]),
+            )),
+        ]);
+
+        assert_eq!(bal.len(), 1);
+        assert_eq!(bal[0].balance_changes.len(), 1);
+        assert_eq!(
+            bal[0].code_changes,
+            vec![CodeChange::new(BlockAccessIndex::new(1), Bytes::from_static(&[0xaa]))]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `Bal::merge` for folding an iterator of `AccountChanges` into a single block access list.

The helper collapses duplicate account entries already present in the BAL or provided by the incoming iterator, using `AccountChanges::merge` to preserve all account-local changes while normalizing storage reads and writes through the existing account merge behavior.

## Impact

Callers can now combine independently produced BAL fragments without manually tracking account positions or risking duplicate account entries in the resulting BAL.