### PR TITLE
fix(eip7928): serialize BAL storage fields as 32-byte values

### DIFF
--- a/crates/eip7928/src/account_changes.rs
+++ b/crates/eip7928/src/account_changes.rs
@@ -24,6 +24,10 @@ pub struct AccountChanges {
     /// List of slot changes for this account.
     pub storage_changes: Vec<SlotChanges>,
     /// List of storage reads for this account.
+    ///
+    /// Serialized as 32-byte zero-padded `bytes32` values per the `execution-apis` schema, while
+    /// deserialization also accepts compact quantity encodings such as `0x0`.
+    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_storage_reads"))]
     pub storage_reads: Vec<U256>,
     /// List of balance changes for this account.
     pub balance_changes: Vec<BalanceChange>,
@@ -222,6 +226,17 @@ impl AccountChanges {
         self.storage_changes.extend(iter);
         self
     }
+}
+
+/// Serializes storage read slots as 32-byte zero-padded `bytes32` values per the `execution-apis`
+/// schema. Deserialization intentionally stays on the default `U256` impl, which accepts both
+/// padded values and compact quantity encodings such as `0x0`.
+#[cfg(feature = "serde")]
+fn serialize_storage_reads<S: serde::Serializer>(
+    values: &[U256],
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    serializer.collect_seq(values.iter().map(|value| alloy_primitives::B256::from(*value)))
 }
 
 fn merge_slot_changes(existing: &mut Vec<SlotChanges>, incoming: Vec<SlotChanges>) {
@@ -517,9 +532,18 @@ mod tests {
 
         let json = serde_json::to_string(&acc).unwrap();
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
-        assert_eq!(value["storageChanges"][0]["key"], "0x1");
-        assert_eq!(value["storageChanges"][0]["changes"][0]["value"], "0x64");
-        assert_eq!(value["storageReads"][0], "0x2");
+        assert_eq!(
+            value["storageChanges"][0]["key"],
+            "0x0000000000000000000000000000000000000000000000000000000000000001"
+        );
+        assert_eq!(
+            value["storageChanges"][0]["changes"][0]["value"],
+            "0x0000000000000000000000000000000000000000000000000000000000000064"
+        );
+        assert_eq!(
+            value["storageReads"][0],
+            "0x0000000000000000000000000000000000000000000000000000000000000002"
+        );
         assert_eq!(value["balanceChanges"][0]["value"], "0x3e8");
         assert_eq!(value["nonceChanges"][0]["value"], "0x2a");
         assert_eq!(value["codeChanges"][0]["code"], "0x6000");
@@ -550,7 +574,11 @@ mod tests {
 
         assert_eq!(
             serde_json::to_value(decoded).unwrap()["storageReads"],
-            serde_json::json!(["0x0", "0x1", "0x2"])
+            serde_json::json!([
+                "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "0x0000000000000000000000000000000000000000000000000000000000000001",
+                "0x0000000000000000000000000000000000000000000000000000000000000002"
+            ])
         );
     }
 
@@ -648,21 +676,21 @@ mod tests {
     "address": "0x1111111111111111111111111111111111111111",
     "storageChanges": [
       {
-        "key": "0x1",
+        "key": "0x0000000000000000000000000000000000000000000000000000000000000001",
         "changes": [
           {
             "index": "0x1",
-            "value": "0x10"
+            "value": "0x0000000000000000000000000000000000000000000000000000000000000010"
           },
           {
             "index": "0x2",
-            "value": "0x20"
+            "value": "0x0000000000000000000000000000000000000000000000000000000000000020"
           }
         ]
       }
     ],
     "storageReads": [
-      "0x2"
+      "0x0000000000000000000000000000000000000000000000000000000000000002"
     ],
     "balanceChanges": [
       {

--- a/crates/eip7928/src/lib.rs
+++ b/crates/eip7928/src/lib.rs
@@ -69,3 +69,14 @@ mod quantity {
         U64::deserialize(deserializer).map(|value| value.to())
     }
 }
+
+/// Serializes a `U256` storage key or value as a 32-byte zero-padded `bytes32` value per the
+/// `execution-apis` schema. Deserialization intentionally stays on the default `U256` impl, which
+/// accepts both padded values and compact quantity encodings such as `0x0`.
+#[cfg(feature = "serde")]
+pub(crate) fn serialize_bytes32<S: serde::Serializer>(
+    value: &alloy_primitives::U256,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    serde::Serialize::serialize(&alloy_primitives::B256::from(*value), serializer)
+}

--- a/crates/eip7928/src/slot_changes.rs
+++ b/crates/eip7928/src/slot_changes.rs
@@ -14,7 +14,13 @@ use alloy_primitives::U256;
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct SlotChanges {
     /// The storage slot key being modified.
-    #[cfg_attr(feature = "serde", serde(rename = "key", alias = "slot"))]
+    ///
+    /// Serialized as a 32-byte zero-padded `bytes32` value per the `execution-apis` schema, while
+    /// deserialization also accepts compact quantity encodings such as `0x0`.
+    #[cfg_attr(
+        feature = "serde",
+        serde(rename = "key", alias = "slot", serialize_with = "crate::serialize_bytes32")
+    )]
     pub slot: U256,
     /// A list of write operations to this slot, ordered by transaction index.
     #[cfg_attr(feature = "serde", serde(alias = "slotChanges"))]

--- a/crates/eip7928/src/storage_change.rs
+++ b/crates/eip7928/src/storage_change.rs
@@ -19,9 +19,17 @@ pub struct StorageChange {
     )]
     pub block_access_index: BlockAccessIndex,
     /// The new value written to the storage slot.
+    ///
+    /// Serialized as a 32-byte zero-padded `bytes32` value per the `execution-apis` schema, while
+    /// deserialization also accepts compact quantity encodings such as `0x0`.
     #[cfg_attr(
         feature = "serde",
-        serde(rename = "value", alias = "newValue", alias = "postValue")
+        serde(
+            rename = "value",
+            alias = "newValue",
+            alias = "postValue",
+            serialize_with = "crate::serialize_bytes32"
+        )
     )]
     pub new_value: U256,
 }


### PR DESCRIPTION
## Motivation

The execution-apis schema for `eth_getBlockAccessList` defines `storageReads`, `storageChanges[].key`, and storage change `value` as `hash32`, i.e. 32-byte zero-padded values (https://github.com/ethereum/execution-apis/blob/main/src/schemas/block-access-list.yaml), and https://hackmd.io/@Nerolation/Hk1WTpuVze flags the current minimal-hex quantity output as non-compliant. #112 fixed the encoding, but its strict 32-byte decoders rejected the `tests-glamsterdam-devnet@v7.2.0` EEST fixtures that use compact quantities such as `0x00` for these fields, which is why #116 and #118 reverted them to plain `U256` serde, reintroducing the non-spec output.

## Solution

Make the serde asymmetric: serialize `storage_reads`, `SlotChanges::slot`, and `StorageChange::new_value` through `B256` so output is spec-compliant zero-padded `bytes32`, while deserialization stays on the default `U256` impl so both padded values and compact quantities remain accepted. This keeps the EEST regression coverage from #116 and #118 passing while restoring the spec encoding from #112.

## Verification

Parsed the entire `tests-glamsterdam-devnet@v7.2.0` fixture corpus with this branch, including a JSON round-trip of every BAL (the padded output re-parses to an equal value):

- 33,466 fixture files scanned
- 29,964 JSON block access lists parsed and round-tripped: 298,004 accounts, 108,134 storage slot keys, 111,831 storage values, 525,399 storage reads, 80,079 balance changes, 43,275 nonce changes, 3,003 code changes (matches the counts reported in #118)
- 30,011 RLP-encoded BALs from the sync/engine fixtures decoded via the `rlp` feature
- 0 failures; the only rejected inputs are 4 deliberately malformed BALs in `expectException` negative-test fixtures

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
