### PR TITLE
fix(eip7928): restore BAL quantity serde

### DIFF
--- a/crates/eip7928/src/account_changes.rs
+++ b/crates/eip7928/src/account_changes.rs
@@ -517,14 +517,8 @@ mod tests {
 
         let json = serde_json::to_string(&acc).unwrap();
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
-        assert_eq!(
-            value["storageChanges"][0]["key"],
-            "0x0000000000000000000000000000000000000000000000000000000000000001"
-        );
-        assert_eq!(
-            value["storageChanges"][0]["changes"][0]["value"],
-            "0x0000000000000000000000000000000000000000000000000000000000000064"
-        );
+        assert_eq!(value["storageChanges"][0]["key"], "0x1");
+        assert_eq!(value["storageChanges"][0]["changes"][0]["value"], "0x64");
         assert_eq!(value["storageReads"][0], "0x2");
         assert_eq!(value["balanceChanges"][0]["value"], "0x3e8");
         assert_eq!(value["nonceChanges"][0]["value"], "0x2a");
@@ -558,6 +552,57 @@ mod tests {
             serde_json::to_value(decoded).unwrap()["storageReads"],
             serde_json::json!(["0x0", "0x1", "0x2"])
         );
+    }
+
+    #[test]
+    fn test_eest_storage_fields_deserialize_compact_quantities() {
+        // Extracted from tests-glamsterdam-devnet@v7.2.0's precompile_warming.json fixture.
+        let fixture = r#"
+        [
+          {
+            "address": "0x0000f90827f1c53a10cb7a02335b175320002935",
+            "storageChanges": [
+              {
+                "slot": "0x01",
+                "slotChanges": [
+                  {
+                    "blockAccessIndex": "0x00",
+                    "postValue": "0x27330b1c525088b9b5ed2ced86b42d53378c8f6b384e8c3897493e851bc026df"
+                  }
+                ]
+              }
+            ],
+            "storageReads": [],
+            "balanceChanges": [],
+            "nonceChanges": [],
+            "codeChanges": []
+          },
+          {
+            "address": "0x000f3df6d732807ef1319fb7b8bb8522d0beac02",
+            "storageChanges": [
+              {
+                "slot": "0x0e22",
+                "slotChanges": [
+                  {
+                    "blockAccessIndex": "0x00",
+                    "postValue": "0x4e20"
+                  }
+                ]
+              }
+            ],
+            "storageReads": ["0x2e21"],
+            "balanceChanges": [],
+            "nonceChanges": [],
+            "codeChanges": []
+          }
+        ]
+        "#;
+
+        let decoded: BlockAccessList = serde_json::from_str(fixture).unwrap();
+        assert_eq!(decoded[0].storage_changes[0].slot, U256::from(1));
+        assert_eq!(decoded[1].storage_changes[0].slot, U256::from(0x0e22));
+        assert_eq!(decoded[1].storage_changes[0].changes[0].new_value, U256::from(0x4e20));
+        assert_eq!(decoded[1].storage_reads, vec![U256::from(0x2e21)]);
     }
 
     #[test]
@@ -603,15 +648,15 @@ mod tests {
     "address": "0x1111111111111111111111111111111111111111",
     "storageChanges": [
       {
-        "key": "0x0000000000000000000000000000000000000000000000000000000000000001",
+        "key": "0x1",
         "changes": [
           {
             "index": "0x1",
-            "value": "0x0000000000000000000000000000000000000000000000000000000000000010"
+            "value": "0x10"
           },
           {
             "index": "0x2",
-            "value": "0x0000000000000000000000000000000000000000000000000000000000000020"
+            "value": "0x20"
           }
         ]
       }

--- a/crates/eip7928/src/lib.rs
+++ b/crates/eip7928/src/lib.rs
@@ -69,25 +69,3 @@ mod quantity {
         U64::deserialize(deserializer).map(|value| value.to())
     }
 }
-
-/// Serde helpers for storage keys and values, which are JSON `bytes32` values rather than
-/// quantity-encoded integers.
-#[cfg(feature = "serde")]
-pub(crate) mod fixed_bytes {
-    use alloy_primitives::{B256, U256};
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-    pub(crate) fn serialize<S>(value: &U256, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        B256::from(*value).serialize(serializer)
-    }
-
-    pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<U256, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        B256::deserialize(deserializer).map(|value| U256::from_be_bytes(value.0))
-    }
-}

--- a/crates/eip7928/src/slot_changes.rs
+++ b/crates/eip7928/src/slot_changes.rs
@@ -14,10 +14,7 @@ use alloy_primitives::U256;
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct SlotChanges {
     /// The storage slot key being modified.
-    #[cfg_attr(
-        feature = "serde",
-        serde(rename = "key", alias = "slot", with = "crate::fixed_bytes")
-    )]
+    #[cfg_attr(feature = "serde", serde(rename = "key", alias = "slot"))]
     pub slot: U256,
     /// A list of write operations to this slot, ordered by transaction index.
     #[cfg_attr(feature = "serde", serde(alias = "slotChanges"))]

--- a/crates/eip7928/src/storage_change.rs
+++ b/crates/eip7928/src/storage_change.rs
@@ -21,12 +21,7 @@ pub struct StorageChange {
     /// The new value written to the storage slot.
     #[cfg_attr(
         feature = "serde",
-        serde(
-            rename = "value",
-            alias = "newValue",
-            alias = "postValue",
-            with = "crate::fixed_bytes"
-        )
+        serde(rename = "value", alias = "newValue", alias = "postValue")
     )]
     pub new_value: U256,
 }


### PR DESCRIPTION
## Motivation

Follow-up to #116. `tests-glamsterdam-devnet@v7.2.0` uses compact, byte-aligned hexadecimal quantities for all BAL storage fields, not only `storageReads`. The remaining fixed-width serde overrides reject real fixture values such as `storageChanges[].slot = "0x01"` and `slotChanges[].postValue = "0x4e20"`.

## Solution

Restore the pre-0.4.6 `U256` serde behavior for:

- `storageReads[]` (landed in #116)
- `storageChanges[].slot`
- `storageChanges[].slotChanges[].postValue`

Remove the now-unused fixed-bytes helper and add regression coverage extracted from the released `precompile_warming.json` fixture. Other BAL fields retain their existing serde: fixed-width addresses, byte code, and quantity-compatible indices, balances, and nonces.

## Verification

Parsed the entire actual `tests-glamsterdam-devnet@v7.2.0` blockchain fixture corpus successfully:

- 11,664 fixture files
- 29,964 block access lists
- 298,004 accounts/addresses
- 108,134 storage slot keys
- 111,831 storage post-values and indices
- 525,399 storage reads
- 80,079 balance changes
- 43,275 nonce changes
- 3,003 code changes

Local checks:

- `cargo test -p alloy-eip7928 --all-features` (69 passed)
- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy -p alloy-eip7928 --all-features --all-targets -- -D warnings`

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

Prompted by: @DaniPopes