### PR TITLE
feat(eip7928): add BAL change insertion

### DIFF
--- a/crates/eip7928/src/account_changes.rs
+++ b/crates/eip7928/src/account_changes.rs
@@ -3,7 +3,8 @@
 //! This eliminates address redundancy across different change types.
 
 use crate::{
-    SlotChanges, balance_change::BalanceChange, code_change::CodeChange, nonce_change::NonceChange,
+    BlockAccessIndex, SlotChanges, balance_change::BalanceChange, code_change::CodeChange,
+    nonce_change::NonceChange,
 };
 use alloc::vec::Vec;
 use alloy_primitives::{
@@ -62,6 +63,26 @@ impl AccountChanges {
     #[inline]
     pub const fn address(&self) -> Address {
         self.address
+    }
+
+    /// Returns `true` if this account change set contains no changes or reads.
+    ///
+    /// A [`SlotChanges`] entry with an empty change list does not count as data, so an entry
+    /// that only carries the address (or empty slot entries) is considered empty.
+    pub fn is_empty(&self) -> bool {
+        let Self {
+            address: _,
+            storage_changes,
+            storage_reads,
+            balance_changes,
+            nonce_changes,
+            code_changes,
+        } = self;
+        storage_changes.iter().all(SlotChanges::is_empty)
+            && storage_reads.is_empty()
+            && balance_changes.is_empty()
+            && nonce_changes.is_empty()
+            && code_changes.is_empty()
     }
 
     /// Returns the storage changes for this account.
@@ -169,6 +190,66 @@ impl AccountChanges {
         self.code_changes.sort_unstable_by_key(|change| change.block_access_index);
     }
 
+    /// Renormalizes this account change set in place.
+    ///
+    /// Empty [`SlotChanges`] entries are dropped, duplicate slot entries are folded together
+    /// (preserving the relative order of their changes), and storage reads are deduplicated and
+    /// pruned against written slots, restoring the EIP-7928 invariant that a slot appears in
+    /// either reads or changes but not both.
+    pub fn normalize(&mut self) {
+        self.storage_changes.retain(|slot_changes| !slot_changes.is_empty());
+        let incoming = core::mem::replace(self, Self::new(self.address));
+        self.merge(incoming);
+    }
+
+    /// Collapses each change list to its last entry and assigns that entry to `at`.
+    ///
+    /// The last entry of each list is treated as the effective value ("last write wins"),
+    /// matching [`Self::storage_post_states`]. Storage reads carry no block access index and are
+    /// left untouched.
+    pub fn collapse_changes_at(&mut self, at: BlockAccessIndex) {
+        let Self {
+            address: _,
+            storage_changes,
+            storage_reads: _,
+            balance_changes,
+            nonce_changes,
+            code_changes,
+        } = self;
+        for slot_changes in storage_changes.iter_mut() {
+            keep_last(&mut slot_changes.changes, |change| change.block_access_index = at);
+        }
+        keep_last(balance_changes, |change| change.block_access_index = at);
+        keep_last(nonce_changes, |change| change.block_access_index = at);
+        keep_last(code_changes, |change| change.block_access_index = at);
+    }
+
+    /// Shifts every recorded block access index at or after `from` forward by one.
+    ///
+    /// Indices saturate at `u64::MAX` instead of overflowing.
+    pub fn shift_indices_from(&mut self, from: BlockAccessIndex) {
+        let Self {
+            address: _,
+            storage_changes,
+            storage_reads: _,
+            balance_changes,
+            nonce_changes,
+            code_changes,
+        } = self;
+        let storage = storage_changes
+            .iter_mut()
+            .flat_map(|slot_changes| slot_changes.changes.iter_mut())
+            .map(|change| &mut change.block_access_index);
+        let balances = balance_changes.iter_mut().map(|change| &mut change.block_access_index);
+        let nonces = nonce_changes.iter_mut().map(|change| &mut change.block_access_index);
+        let codes = code_changes.iter_mut().map(|change| &mut change.block_access_index);
+        for index in storage.chain(balances).chain(nonces).chain(codes) {
+            if *index >= from {
+                index.saturating_increment();
+            }
+        }
+    }
+
     /// Set the address.
     pub const fn with_address(mut self, address: Address) -> Self {
         self.address = address;
@@ -221,6 +302,15 @@ impl AccountChanges {
     {
         self.storage_changes.extend(iter);
         self
+    }
+}
+
+/// Keeps only the last entry of the list, applying `stamp` to it.
+fn keep_last<T>(changes: &mut Vec<T>, stamp: impl FnOnce(&mut T)) {
+    if let Some(mut change) = changes.pop() {
+        stamp(&mut change);
+        changes.clear();
+        changes.push(change);
     }
 }
 

--- a/crates/eip7928/src/block_access_index.rs
+++ b/crates/eip7928/src/block_access_index.rs
@@ -53,6 +53,12 @@ impl BlockAccessIndex {
         self.0 += 1;
     }
 
+    /// Bumps the index by 1, saturating at `u64::MAX` instead of overflowing.
+    #[inline]
+    pub const fn saturating_increment(&mut self) {
+        self.0 = self.0.saturating_add(1);
+    }
+
     /// Classifies this index into a [`BlockAccessPhase`], given the number of transactions
     /// in the block.
     ///

--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -192,6 +192,23 @@ pub mod bal {
         /// `block_access_index` should use the returned index to observe the inserted changes while
         /// preserving the original BAL state at that position.
         ///
+        /// BAL reads observe changes strictly before the positioned index, so inserting a layer
+        /// moves the read position forward with the original suffix:
+        ///
+        /// ```text
+        /// before: [change 0] [change 1] | read @ 2 | [change 2] [change 3]
+        /// after:  [change 0] [change 1] [override @ 2] | read @ 3 | [change 3] [change 4]
+        /// ```
+        ///
+        /// This effectively allows RPC-style state overrides to be applied directly to a positioned
+        /// BAL: convert the overridden balance, nonce, code, and storage values into
+        /// [`AccountChanges`], insert them at the current position, then continue reading at the
+        /// returned index. No parallel override field or cache is required.
+        ///
+        /// A full storage replacement cannot be represented completely by a BAL alone. Known BAL
+        /// slots can be zeroed in the inserted layer, but fallback reads for slots absent from the
+        /// BAL still require replacement-aware backing state.
+        ///
         /// If `incoming` contains no account data, the BAL and returned index are unchanged.
         pub fn insert_changes_at<I>(
             &mut self,

--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -43,8 +43,8 @@ pub fn total_bal_items(bal: &[AccountChanges]) -> u64 {
 pub mod bal {
     use super::OnceLock;
     use crate::{
-        BlockAccessListGasError, BlockAccessListHashMismatch, account_changes::AccountChanges,
-        diff::BalDiff,
+        BlockAccessIndex, BlockAccessListGasError, BlockAccessListHashMismatch,
+        account_changes::AccountChanges, diff::BalDiff,
     };
     use alloc::vec::{IntoIter, Vec};
     use alloy_primitives::{B256, Bytes, map::HashMap};
@@ -179,6 +179,48 @@ pub mod bal {
             }
 
             self.0 = merged_accounts;
+        }
+
+        /// Inserts a synthetic change layer at `block_access_index`.
+        ///
+        /// Existing changes at or after the insertion point are shifted forward by one. All
+        /// supplied changes are assigned to the insertion point, duplicate accounts and storage
+        /// slots are merged, and duplicate writes within the inserted layer use the last supplied
+        /// value. The resulting BAL is sorted canonically.
+        ///
+        /// Returns the index immediately after the inserted layer. Callers positioned at
+        /// `block_access_index` should use the returned index to observe the inserted changes while
+        /// preserving the original BAL state at that position.
+        ///
+        /// If `incoming` contains no account data, the BAL and returned index are unchanged.
+        pub fn insert_changes_at<I>(
+            &mut self,
+            block_access_index: BlockAccessIndex,
+            incoming: I,
+        ) -> BlockAccessIndex
+        where
+            I: IntoIterator<Item = AccountChanges>,
+        {
+            let mut inserted = Self::default();
+            inserted.merge(incoming);
+            inserted.0.retain(account_has_data);
+            if inserted.is_empty() {
+                return block_access_index;
+            }
+
+            for account in &mut self.0 {
+                shift_account_changes(account, block_access_index);
+            }
+            for account in &mut inserted.0 {
+                normalize_inserted_account(account, block_access_index);
+            }
+
+            self.merge(inserted);
+            self.sort();
+
+            let mut positioned_index = block_access_index;
+            positioned_index.increment();
+            positioned_index
         }
 
         /// Returns `true` if the list contains no elements.
@@ -334,6 +376,66 @@ pub mod bal {
                 return crate::constants::EMPTY_BLOCK_ACCESS_LIST_HASH;
             }
             super::compute_block_access_list_hash_with_buf(&self.0, buf)
+        }
+    }
+
+    const fn account_has_data(account: &AccountChanges) -> bool {
+        !account.storage_changes.is_empty()
+            || !account.storage_reads.is_empty()
+            || !account.balance_changes.is_empty()
+            || !account.nonce_changes.is_empty()
+            || !account.code_changes.is_empty()
+    }
+
+    fn shift_account_changes(account: &mut AccountChanges, from: BlockAccessIndex) {
+        for slot in &mut account.storage_changes {
+            for change in &mut slot.changes {
+                if change.block_access_index >= from {
+                    change.block_access_index.increment();
+                }
+            }
+        }
+        for change in &mut account.balance_changes {
+            if change.block_access_index >= from {
+                change.block_access_index.increment();
+            }
+        }
+        for change in &mut account.nonce_changes {
+            if change.block_access_index >= from {
+                change.block_access_index.increment();
+            }
+        }
+        for change in &mut account.code_changes {
+            if change.block_access_index >= from {
+                change.block_access_index.increment();
+            }
+        }
+    }
+
+    fn normalize_inserted_account(account: &mut AccountChanges, at: BlockAccessIndex) {
+        for slot in &mut account.storage_changes {
+            if let Some(mut change) = slot.changes.pop() {
+                change.block_access_index = at;
+                slot.changes.clear();
+                slot.changes.push(change);
+            }
+        }
+        account.storage_changes.retain(|slot| !slot.changes.is_empty());
+
+        if let Some(mut change) = account.balance_changes.pop() {
+            change.block_access_index = at;
+            account.balance_changes.clear();
+            account.balance_changes.push(change);
+        }
+        if let Some(mut change) = account.nonce_changes.pop() {
+            change.block_access_index = at;
+            account.nonce_changes.clear();
+            account.nonce_changes.push(change);
+        }
+        if let Some(mut change) = account.code_changes.pop() {
+            change.block_access_index = at;
+            account.code_changes.clear();
+            account.code_changes.push(change);
         }
     }
 
@@ -1359,6 +1461,115 @@ mod hash_tests {
             bal[0].code_changes,
             vec![CodeChange::new(BlockAccessIndex::new(1), Bytes::from_static(&[0xaa]))]
         );
+    }
+
+    #[test]
+    fn bal_insert_changes_shifts_suffix_and_normalizes_inserted_layer() {
+        let existing_address = Address::from([0x22; 20]);
+        let new_address = Address::from([0x11; 20]);
+        let slot = U256::from(1);
+        let mut bal = Bal::new(vec![AccountChanges {
+            address: existing_address,
+            storage_changes: vec![SlotChanges::new(
+                slot,
+                vec![StorageChange::new(BlockAccessIndex::new(2), U256::from(20))],
+            )],
+            storage_reads: vec![U256::from(2)],
+            balance_changes: vec![
+                BalanceChange::new(BlockAccessIndex::new(1), U256::from(100)),
+                BalanceChange::new(BlockAccessIndex::new(2), U256::from(200)),
+                BalanceChange::new(BlockAccessIndex::new(3), U256::from(300)),
+            ],
+            nonce_changes: vec![NonceChange::new(BlockAccessIndex::new(2), 2)],
+            code_changes: vec![CodeChange::new(
+                BlockAccessIndex::new(2),
+                Bytes::from_static(&[0x60, 0x02]),
+            )],
+        }]);
+
+        let positioned_index = bal.insert_changes_at(
+            BlockAccessIndex::new(2),
+            [
+                AccountChanges::new(existing_address)
+                    .with_storage_change(SlotChanges::new(
+                        slot,
+                        vec![StorageChange::new(BlockAccessIndex::new(90), U256::from(900))],
+                    ))
+                    .with_balance_change(BalanceChange::new(
+                        BlockAccessIndex::new(90),
+                        U256::from(900),
+                    )),
+                AccountChanges::new(existing_address)
+                    .with_storage_change(SlotChanges::new(
+                        slot,
+                        vec![StorageChange::new(BlockAccessIndex::new(91), U256::from(901))],
+                    ))
+                    .with_balance_change(BalanceChange::new(
+                        BlockAccessIndex::new(91),
+                        U256::from(901),
+                    ))
+                    .with_nonce_change(NonceChange::new(BlockAccessIndex::new(91), 9)),
+                AccountChanges::new(new_address).with_code_change(CodeChange::new(
+                    BlockAccessIndex::new(92),
+                    Bytes::from_static(&[0x60, 0x09]),
+                )),
+            ],
+        );
+
+        assert_eq!(positioned_index, BlockAccessIndex::new(3));
+        assert_eq!(
+            bal.iter().map(AccountChanges::address).collect::<Vec<_>>(),
+            vec![new_address, existing_address]
+        );
+
+        assert_eq!(
+            bal[0].code_changes,
+            vec![CodeChange::new(BlockAccessIndex::new(2), Bytes::from_static(&[0x60, 0x09]))]
+        );
+        assert_eq!(
+            bal[1].balance_changes,
+            vec![
+                BalanceChange::new(BlockAccessIndex::new(1), U256::from(100)),
+                BalanceChange::new(BlockAccessIndex::new(2), U256::from(901)),
+                BalanceChange::new(BlockAccessIndex::new(3), U256::from(200)),
+                BalanceChange::new(BlockAccessIndex::new(4), U256::from(300)),
+            ]
+        );
+        assert_eq!(
+            bal[1].storage_changes[0].changes,
+            vec![
+                StorageChange::new(BlockAccessIndex::new(2), U256::from(901)),
+                StorageChange::new(BlockAccessIndex::new(3), U256::from(20)),
+            ]
+        );
+        assert_eq!(
+            bal[1].nonce_changes,
+            vec![
+                NonceChange::new(BlockAccessIndex::new(2), 9),
+                NonceChange::new(BlockAccessIndex::new(3), 2),
+            ]
+        );
+        assert_eq!(
+            bal[1].code_changes,
+            vec![CodeChange::new(BlockAccessIndex::new(3), Bytes::from_static(&[0x60, 0x02]))]
+        );
+    }
+
+    #[test]
+    fn bal_insert_empty_changes_is_noop() {
+        let original =
+            Bal::new(vec![AccountChanges::new(Address::from([0x11; 20])).with_balance_change(
+                BalanceChange::new(BlockAccessIndex::new(1), U256::from(100)),
+            )]);
+        let mut bal = original.clone();
+
+        let positioned_index = bal.insert_changes_at(
+            BlockAccessIndex::new(1),
+            [AccountChanges::new(Address::from([0x22; 20]))],
+        );
+
+        assert_eq!(positioned_index, BlockAccessIndex::new(1));
+        assert_eq!(bal, original);
     }
 
     #[test]

--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -1806,6 +1806,124 @@ mod hash_tests {
         );
     }
 
+    /// Demonstrates how RPC-style state overrides — nested per-account override data built from
+    /// plain primitives — are applied to a positioned BAL and observed at the returned index.
+    #[test]
+    fn bal_insert_applies_state_overrides() {
+        let alice = Address::from([0xaa; 20]);
+        let bob = Address::from([0xbb; 20]);
+        let slot = U256::from(1);
+
+        // BAL for a 3-tx block: alice's balance and storage slot are written by txs 0..=2
+        // (block access indices 1..=3). The caller simulates positioned at index 2.
+        let mut bal = Bal::new(vec![
+            AccountChanges::new(alice)
+                .with_storage_change(SlotChanges::new(
+                    slot,
+                    vec![
+                        StorageChange::new(BlockAccessIndex::new(2), U256::from(20)),
+                        StorageChange::new(BlockAccessIndex::new(3), U256::from(30)),
+                    ],
+                ))
+                .with_balance_change(BalanceChange::new(BlockAccessIndex::new(1), U256::from(100)))
+                .with_balance_change(BalanceChange::new(BlockAccessIndex::new(2), U256::from(200)))
+                .with_balance_change(BalanceChange::new(BlockAccessIndex::new(3), U256::from(300))),
+        ]);
+
+        // Effective balance at a position: latest change strictly before it.
+        let balance_at = |account: &AccountChanges, position: BlockAccessIndex| {
+            account
+                .balance_changes
+                .iter()
+                .rfind(|change| change.block_access_index < position)
+                .map(|change| change.post_balance)
+        };
+        let position = BlockAccessIndex::new(2);
+        assert_eq!(balance_at(&bal[0], position), Some(U256::from(100)));
+
+        // Override data as an RPC layer would carry it:
+        // (address, balance, nonce, code, [(slot, value)]) — no BAL indices involved.
+        let overrides = [
+            (alice, Some(U256::from(999)), None, None, vec![(slot, U256::from(90))]),
+            (
+                bob,
+                None,
+                Some(7),
+                Some(Bytes::from_static(&[0x60, 0x00])),
+                vec![(U256::from(5), U256::from(50))],
+            ),
+            // a later entry for an already overridden account wins
+            (alice, Some(U256::from(1000)), None, None, vec![]),
+        ];
+
+        // Conversion uses a placeholder index; `insert_changes_at` restamps every change to the
+        // insertion point.
+        let placeholder = BlockAccessIndex::PRE_EXECUTION;
+        let overlay = overrides.into_iter().map(|(address, balance, nonce, code, slots)| {
+            let mut account = AccountChanges::new(address);
+            if let Some(balance) = balance {
+                account = account.with_balance_change(BalanceChange::new(placeholder, balance));
+            }
+            if let Some(nonce) = nonce {
+                account = account.with_nonce_change(NonceChange::new(placeholder, nonce));
+            }
+            if let Some(code) = code {
+                account = account.with_code_change(CodeChange::new(placeholder, code));
+            }
+            for (slot, value) in slots {
+                account = account.with_storage_change(SlotChanges::new(
+                    slot,
+                    vec![StorageChange::new(placeholder, value)],
+                ));
+            }
+            account
+        });
+
+        let positioned_index = bal.insert_changes_at(position, overlay);
+        assert_eq!(positioned_index, BlockAccessIndex::new(3));
+
+        // The override layer sits at the insertion point, the original suffix follows it.
+        assert_eq!(
+            bal[0].balance_changes,
+            vec![
+                BalanceChange::new(BlockAccessIndex::new(1), U256::from(100)),
+                BalanceChange::new(BlockAccessIndex::new(2), U256::from(1000)),
+                BalanceChange::new(BlockAccessIndex::new(3), U256::from(200)),
+                BalanceChange::new(BlockAccessIndex::new(4), U256::from(300)),
+            ]
+        );
+        assert_eq!(
+            bal[0].storage_changes,
+            vec![SlotChanges::new(
+                slot,
+                vec![
+                    StorageChange::new(BlockAccessIndex::new(2), U256::from(90)),
+                    StorageChange::new(BlockAccessIndex::new(3), U256::from(20)),
+                    StorageChange::new(BlockAccessIndex::new(4), U256::from(30)),
+                ],
+            )]
+        );
+        assert_eq!(bal[1].address, bob);
+        assert_eq!(bal[1].nonce_changes, vec![NonceChange::new(BlockAccessIndex::new(2), 7)]);
+        assert_eq!(
+            bal[1].code_changes,
+            vec![CodeChange::new(BlockAccessIndex::new(2), Bytes::from_static(&[0x60, 0x00]))]
+        );
+        assert_eq!(
+            bal[1].storage_changes,
+            vec![SlotChanges::new(
+                U256::from(5),
+                vec![StorageChange::new(BlockAccessIndex::new(2), U256::from(50))],
+            )]
+        );
+
+        // The original position still observes pre-override state, the returned index observes
+        // the override, and positions past the shifted suffix observe the original final value.
+        assert_eq!(balance_at(&bal[0], position), Some(U256::from(100)));
+        assert_eq!(balance_at(&bal[0], positioned_index), Some(U256::from(1000)));
+        assert_eq!(balance_at(&bal[0], BlockAccessIndex::new(5)), Some(U256::from(300)));
+    }
+
     #[test]
     fn bal_sort_orders_all_eip7928_lists() {
         let address_1 = Address::from([0x11; 20]);

--- a/crates/eip7928/src/block_access_list.rs
+++ b/crates/eip7928/src/block_access_list.rs
@@ -183,10 +183,18 @@ pub mod bal {
 
         /// Inserts a synthetic change layer at `block_access_index`.
         ///
-        /// Existing changes at or after the insertion point are shifted forward by one. All
-        /// supplied changes are assigned to the insertion point, duplicate accounts and storage
-        /// slots are merged, and duplicate writes within the inserted layer use the last supplied
-        /// value. The resulting BAL is sorted canonically.
+        /// The supplied change sets are normalized first: duplicate accounts and duplicate slot
+        /// entries are folded, empty slot entries are dropped, storage reads are deduplicated and
+        /// pruned against written slots, and duplicate writes within the inserted layer collapse
+        /// to the last supplied value. Accounts that carry no data after normalization are
+        /// ignored.
+        ///
+        /// Existing changes at or after the insertion point are shifted forward by one
+        /// (saturating at `u64::MAX`), the collapsed changes are assigned to the insertion point,
+        /// and the BAL is renormalized into canonical EIP-7928 order, which also folds any
+        /// duplicate account entries that were already present. Inserting a layer grows the
+        /// block's index domain by one, so classifying shifted indices with
+        /// [`BlockAccessIndex::phase`] requires the grown transaction count.
         ///
         /// Returns the index immediately after the inserted layer. Callers positioned at
         /// `block_access_index` should use the returned index to observe the inserted changes while
@@ -209,7 +217,11 @@ pub mod bal {
         /// slots can be zeroed in the inserted layer, but fallback reads for slots absent from the
         /// BAL still require replacement-aware backing state.
         ///
-        /// If `incoming` contains no account data, the BAL and returned index are unchanged.
+        /// Storage reads carry no block access index: supplied reads are merged into the affected
+        /// accounts without reserving a layer, so input that normalizes to reads only leaves all
+        /// indices (and the returned index) unchanged. If `incoming` contains no account data, the
+        /// BAL and returned index are unchanged.
+        #[must_use = "the returned index replaces the caller's position after the inserted layer"]
         pub fn insert_changes_at<I>(
             &mut self,
             block_access_index: BlockAccessIndex,
@@ -219,24 +231,38 @@ pub mod bal {
             I: IntoIterator<Item = AccountChanges>,
         {
             let mut inserted = Self::default();
-            inserted.merge(incoming);
-            inserted.0.retain(account_has_data);
+            // Empty slot entries must be dropped before merging so they cannot mask a supplied
+            // read of the same slot as written.
+            inserted.merge(incoming.into_iter().map(|mut account| {
+                account.storage_changes.retain(|slot_changes| !slot_changes.is_empty());
+                account
+            }));
+            for account in &mut inserted.0 {
+                account.normalize();
+                account.collapse_changes_at(block_access_index);
+            }
+            inserted.0.retain(|account| !account.is_empty());
             if inserted.is_empty() {
                 return block_access_index;
             }
 
-            for account in &mut self.0 {
-                shift_account_changes(account, block_access_index);
-            }
-            for account in &mut inserted.0 {
-                normalize_inserted_account(account, block_access_index);
+            // Reads carry no index, so a layer (and the associated suffix shift) is only needed
+            // when at least one indexed change is inserted.
+            let inserts_layer = inserted.0.iter().any(has_indexed_changes);
+            if inserts_layer {
+                for account in &mut self.0 {
+                    account.shift_indices_from(block_access_index);
+                }
             }
 
             self.merge(inserted);
             self.sort();
 
+            if !inserts_layer {
+                return block_access_index;
+            }
             let mut positioned_index = block_access_index;
-            positioned_index.increment();
+            positioned_index.saturating_increment();
             positioned_index
         }
 
@@ -396,64 +422,20 @@ pub mod bal {
         }
     }
 
-    const fn account_has_data(account: &AccountChanges) -> bool {
-        !account.storage_changes.is_empty()
-            || !account.storage_reads.is_empty()
-            || !account.balance_changes.is_empty()
-            || !account.nonce_changes.is_empty()
-            || !account.code_changes.is_empty()
-    }
-
-    fn shift_account_changes(account: &mut AccountChanges, from: BlockAccessIndex) {
-        for slot in &mut account.storage_changes {
-            for change in &mut slot.changes {
-                if change.block_access_index >= from {
-                    change.block_access_index.increment();
-                }
-            }
-        }
-        for change in &mut account.balance_changes {
-            if change.block_access_index >= from {
-                change.block_access_index.increment();
-            }
-        }
-        for change in &mut account.nonce_changes {
-            if change.block_access_index >= from {
-                change.block_access_index.increment();
-            }
-        }
-        for change in &mut account.code_changes {
-            if change.block_access_index >= from {
-                change.block_access_index.increment();
-            }
-        }
-    }
-
-    fn normalize_inserted_account(account: &mut AccountChanges, at: BlockAccessIndex) {
-        for slot in &mut account.storage_changes {
-            if let Some(mut change) = slot.changes.pop() {
-                change.block_access_index = at;
-                slot.changes.clear();
-                slot.changes.push(change);
-            }
-        }
-        account.storage_changes.retain(|slot| !slot.changes.is_empty());
-
-        if let Some(mut change) = account.balance_changes.pop() {
-            change.block_access_index = at;
-            account.balance_changes.clear();
-            account.balance_changes.push(change);
-        }
-        if let Some(mut change) = account.nonce_changes.pop() {
-            change.block_access_index = at;
-            account.nonce_changes.clear();
-            account.nonce_changes.push(change);
-        }
-        if let Some(mut change) = account.code_changes.pop() {
-            change.block_access_index = at;
-            account.code_changes.clear();
-            account.code_changes.push(change);
-        }
+    /// Returns `true` if the account carries changes that occupy a block access index.
+    const fn has_indexed_changes(account: &AccountChanges) -> bool {
+        let AccountChanges {
+            address: _,
+            storage_changes,
+            storage_reads: _,
+            balance_changes,
+            nonce_changes,
+            code_changes,
+        } = account;
+        !storage_changes.is_empty()
+            || !balance_changes.is_empty()
+            || !nonce_changes.is_empty()
+            || !code_changes.is_empty()
     }
 
     /// Summary of change counts in a BAL for metrics reporting.
@@ -1570,6 +1552,7 @@ mod hash_tests {
             bal[1].code_changes,
             vec![CodeChange::new(BlockAccessIndex::new(3), Bytes::from_static(&[0x60, 0x02]))]
         );
+        assert_eq!(bal[1].storage_reads, vec![U256::from(2)]);
     }
 
     #[test]
@@ -1587,6 +1570,240 @@ mod hash_tests {
 
         assert_eq!(positioned_index, BlockAccessIndex::new(1));
         assert_eq!(bal, original);
+    }
+
+    #[test]
+    fn bal_insert_shifts_untouched_accounts() {
+        let touched = Address::from([0x11; 20]);
+        let bystander = Address::from([0x22; 20]);
+        let mut bal = Bal::new(vec![
+            AccountChanges::new(touched)
+                .with_balance_change(BalanceChange::new(BlockAccessIndex::new(2), U256::from(100))),
+            AccountChanges::new(bystander)
+                .with_storage_change(SlotChanges::new(
+                    U256::from(1),
+                    vec![StorageChange::new(BlockAccessIndex::new(2), U256::from(20))],
+                ))
+                .with_balance_change(BalanceChange::new(BlockAccessIndex::new(1), U256::from(50)))
+                .with_nonce_change(NonceChange::new(BlockAccessIndex::new(2), 7))
+                .with_code_change(CodeChange::new(
+                    BlockAccessIndex::new(3),
+                    Bytes::from_static(&[0x60]),
+                )),
+        ]);
+
+        let positioned_index = bal.insert_changes_at(
+            BlockAccessIndex::new(2),
+            [AccountChanges::new(touched).with_balance_change(BalanceChange::new(
+                BlockAccessIndex::new(0),
+                U256::from(900),
+            ))],
+        );
+
+        assert_eq!(positioned_index, BlockAccessIndex::new(3));
+        assert_eq!(
+            bal[0].balance_changes,
+            vec![
+                BalanceChange::new(BlockAccessIndex::new(2), U256::from(900)),
+                BalanceChange::new(BlockAccessIndex::new(3), U256::from(100)),
+            ]
+        );
+        assert_eq!(bal[1].address, bystander);
+        assert_eq!(
+            bal[1].storage_changes,
+            vec![SlotChanges::new(
+                U256::from(1),
+                vec![StorageChange::new(BlockAccessIndex::new(3), U256::from(20))],
+            )]
+        );
+        assert_eq!(
+            bal[1].balance_changes,
+            vec![BalanceChange::new(BlockAccessIndex::new(1), U256::from(50))]
+        );
+        assert_eq!(bal[1].nonce_changes, vec![NonceChange::new(BlockAccessIndex::new(3), 7)]);
+        assert_eq!(
+            bal[1].code_changes,
+            vec![CodeChange::new(BlockAccessIndex::new(4), Bytes::from_static(&[0x60]))]
+        );
+    }
+
+    #[test]
+    fn bal_insert_folds_duplicate_slot_entries() {
+        let slot = U256::from(7);
+
+        let new_address = Address::from([0x11; 20]);
+        let mut bal = Bal::default();
+        let positioned_index = bal.insert_changes_at(
+            BlockAccessIndex::new(1),
+            [AccountChanges::new(new_address)
+                .with_storage_change(SlotChanges::new(
+                    slot,
+                    vec![StorageChange::new(BlockAccessIndex::new(90), U256::from(900))],
+                ))
+                .with_storage_change(SlotChanges::new(
+                    slot,
+                    vec![StorageChange::new(BlockAccessIndex::new(91), U256::from(901))],
+                ))],
+        );
+        assert_eq!(positioned_index, BlockAccessIndex::new(2));
+        assert_eq!(
+            bal[0].storage_changes,
+            vec![SlotChanges::new(
+                slot,
+                vec![StorageChange::new(BlockAccessIndex::new(1), U256::from(901))],
+            )]
+        );
+
+        let existing = Address::from([0x22; 20]);
+        let mut bal =
+            Bal::new(vec![AccountChanges::new(existing).with_storage_change(SlotChanges::new(
+                slot,
+                vec![StorageChange::new(BlockAccessIndex::new(1), U256::from(10))],
+            ))]);
+        let positioned_index = bal.insert_changes_at(
+            BlockAccessIndex::new(1),
+            [AccountChanges::new(existing)
+                .with_storage_change(SlotChanges::new(
+                    slot,
+                    vec![StorageChange::new(BlockAccessIndex::new(90), U256::from(900))],
+                ))
+                .with_storage_change(SlotChanges::new(
+                    slot,
+                    vec![StorageChange::new(BlockAccessIndex::new(91), U256::from(901))],
+                ))],
+        );
+        assert_eq!(positioned_index, BlockAccessIndex::new(2));
+        assert_eq!(
+            bal[0].storage_changes,
+            vec![SlotChanges::new(
+                slot,
+                vec![
+                    StorageChange::new(BlockAccessIndex::new(1), U256::from(901)),
+                    StorageChange::new(BlockAccessIndex::new(2), U256::from(10)),
+                ],
+            )]
+        );
+    }
+
+    #[test]
+    fn bal_insert_normalizes_reads_for_new_accounts() {
+        let address = Address::from([0x11; 20]);
+        let written = U256::from(1);
+        let read = U256::from(2);
+        let mut bal = Bal::default();
+
+        let positioned_index = bal.insert_changes_at(
+            BlockAccessIndex::new(0),
+            [AccountChanges::new(address)
+                .with_storage_read(written)
+                .with_storage_read(read)
+                .with_storage_read(read)
+                .with_storage_change(SlotChanges::new(
+                    written,
+                    vec![StorageChange::new(BlockAccessIndex::new(9), U256::from(90))],
+                ))],
+        );
+
+        assert_eq!(positioned_index, BlockAccessIndex::new(1));
+        assert_eq!(
+            bal[0].storage_changes,
+            vec![SlotChanges::new(
+                written,
+                vec![StorageChange::new(BlockAccessIndex::new(0), U256::from(90))],
+            )]
+        );
+        assert_eq!(bal[0].storage_reads, vec![read]);
+    }
+
+    #[test]
+    fn bal_insert_empty_slot_entries_are_noop() {
+        let original =
+            Bal::new(vec![AccountChanges::new(Address::from([0x11; 20])).with_balance_change(
+                BalanceChange::new(BlockAccessIndex::new(1), U256::from(100)),
+            )]);
+        let mut bal = original.clone();
+
+        let positioned_index = bal.insert_changes_at(
+            BlockAccessIndex::new(1),
+            [AccountChanges::new(Address::from([0x22; 20]))
+                .with_storage_change(SlotChanges::new(U256::from(1), vec![]))],
+        );
+
+        assert_eq!(positioned_index, BlockAccessIndex::new(1));
+        assert_eq!(bal, original);
+    }
+
+    #[test]
+    fn bal_insert_empty_slot_entry_does_not_swallow_read() {
+        let address = Address::from([0x11; 20]);
+        let slot = U256::from(42);
+        let mut bal = Bal::default();
+
+        let positioned_index = bal.insert_changes_at(
+            BlockAccessIndex::new(3),
+            [
+                AccountChanges::new(address).with_storage_read(slot),
+                AccountChanges::new(address).with_storage_change(SlotChanges::new(slot, vec![])),
+            ],
+        );
+
+        assert_eq!(positioned_index, BlockAccessIndex::new(3));
+        assert_eq!(bal[0].storage_reads, vec![slot]);
+        assert!(bal[0].storage_changes.is_empty());
+    }
+
+    #[test]
+    fn bal_insert_reads_only_does_not_shift() {
+        let address = Address::from([0x11; 20]);
+        let written = U256::from(1);
+        let mut bal =
+            Bal::new(vec![AccountChanges::new(address).with_storage_change(SlotChanges::new(
+                written,
+                vec![StorageChange::new(BlockAccessIndex::new(4), U256::from(40))],
+            ))]);
+        let original = bal.clone();
+
+        // a read of an already written slot is absorbed entirely
+        let positioned_index = bal.insert_changes_at(
+            BlockAccessIndex::new(1),
+            [AccountChanges::new(address).with_storage_read(written)],
+        );
+        assert_eq!(positioned_index, BlockAccessIndex::new(1));
+        assert_eq!(bal, original);
+
+        // novel reads are merged without reserving a layer
+        let novel = U256::from(2);
+        let positioned_index = bal.insert_changes_at(
+            BlockAccessIndex::new(1),
+            [AccountChanges::new(address).with_storage_read(novel)],
+        );
+        assert_eq!(positioned_index, BlockAccessIndex::new(1));
+        assert_eq!(bal[0].storage_reads, vec![novel]);
+        assert_eq!(bal[0].storage_changes, original[0].storage_changes);
+    }
+
+    #[test]
+    fn bal_insert_saturates_index_overflow() {
+        let address = Address::from([0x11; 20]);
+        let mut bal = Bal::new(vec![AccountChanges::new(address).with_balance_change(
+            BalanceChange::new(BlockAccessIndex::new(u64::MAX), U256::from(1)),
+        )]);
+
+        let positioned_index = bal.insert_changes_at(
+            BlockAccessIndex::new(u64::MAX),
+            [AccountChanges::new(address)
+                .with_nonce_change(NonceChange::new(BlockAccessIndex::new(0), 1))],
+        );
+
+        assert_eq!(positioned_index, BlockAccessIndex::new(u64::MAX));
+        assert_eq!(
+            bal[0].balance_changes,
+            vec![BalanceChange::new(BlockAccessIndex::new(u64::MAX), U256::from(1))]
+        );
+        assert_eq!(
+            bal[0].nonce_changes,
+            vec![NonceChange::new(BlockAccessIndex::new(u64::MAX), 1)]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Adds `Bal::insert_changes_at` for injecting a synthetic state-change layer at a positioned BAL index. Incoming change sets are fully normalized before insertion: duplicate accounts and slot entries are folded with last-write-wins semantics, empty slot entries are dropped, and storage reads are deduplicated and pruned against written slots, so the EIP-7928 reads/changes exclusivity holds regardless of whether an account already exists in the BAL. The original suffix is then shifted forward (saturating on index overflow), canonical ordering is restored, and the adjusted read index is returned.

Storage reads carry no block access index, so input that normalizes to reads only is merged without reserving a layer and leaves all indices unchanged. The per-account steps live on `AccountChanges` (`normalize`, `collapse_changes_at`, `shift_indices_from`, `is_empty`) with exhaustive destructuring, so a future field added to the struct is a compile error rather than a silently unshifted list.

This lets consumers apply state overrides through the BAL itself instead of maintaining a separate overlay.