### PR TITLE
feat(eip7928): add account storage slots iterator

### DIFF
--- a/crates/eip7928/src/account_changes.rs
+++ b/crates/eip7928/src/account_changes.rs
@@ -91,6 +91,21 @@ impl AccountChanges {
         &self.storage_changes
     }
 
+    /// Returns an iterator over storage slots present in this account's changes and reads.
+    ///
+    /// Changed slots are yielded first, followed by read slots.
+    #[inline]
+    pub fn storage_slots(&self) -> impl ExactSizeIterator<Item = U256> + '_ {
+        let changed_len = self.storage_changes.len();
+        (0..changed_len + self.storage_reads.len()).map(move |index| {
+            if index < changed_len {
+                self.storage_changes[index].slot
+            } else {
+                self.storage_reads[index - changed_len]
+            }
+        })
+    }
+
     /// Returns an iterator over the post-state value for each changed storage slot.
     ///
     /// The post-state value is taken from the last recorded change for each slot.
@@ -568,6 +583,33 @@ mod post_state_tests {
             post_states,
             vec![(U256::from(1), U256::from(0xbb)), (U256::from(3), U256::from(0xdd))]
         );
+    }
+}
+
+#[cfg(test)]
+mod storage_slots_tests {
+    use crate::{BlockAccessIndex, StorageChange};
+
+    use super::*;
+
+    #[test]
+    fn storage_slots_yields_changed_then_read_slots() {
+        let account = AccountChanges::new(Address::ZERO)
+            .with_storage_change(SlotChanges::new(
+                U256::from(1),
+                vec![StorageChange::new(BlockAccessIndex::new(0), U256::ZERO)],
+            ))
+            .with_storage_change(SlotChanges::new(
+                U256::from(2),
+                vec![StorageChange::new(BlockAccessIndex::new(1), U256::ZERO)],
+            ))
+            .extend_storage_reads([U256::from(3), U256::from(4)]);
+
+        let mut slots = account.storage_slots();
+        assert_eq!(slots.len(), 4);
+        assert_eq!(slots.next(), Some(U256::from(1)));
+        assert_eq!(slots.len(), 3);
+        assert_eq!(slots.collect::<Vec<_>>(), vec![U256::from(2), U256::from(3), U256::from(4)]);
     }
 }
 

--- a/crates/eip7928/src/account_changes.rs
+++ b/crates/eip7928/src/account_changes.rs
@@ -95,15 +95,11 @@ impl AccountChanges {
     ///
     /// Changed slots are yielded first, followed by read slots.
     #[inline]
-    pub fn storage_slots(&self) -> impl ExactSizeIterator<Item = U256> + '_ {
-        let changed_len = self.storage_changes.len();
-        (0..changed_len + self.storage_reads.len()).map(move |index| {
-            if index < changed_len {
-                self.storage_changes[index].slot
-            } else {
-                self.storage_reads[index - changed_len]
-            }
-        })
+    pub fn storage_slots(&self) -> impl Iterator<Item = U256> + '_ {
+        self.storage_changes
+            .iter()
+            .map(|changes| changes.slot)
+            .chain(self.storage_reads.iter().copied())
     }
 
     /// Returns an iterator over the post-state value for each changed storage slot.
@@ -605,11 +601,10 @@ mod storage_slots_tests {
             ))
             .extend_storage_reads([U256::from(3), U256::from(4)]);
 
-        let mut slots = account.storage_slots();
-        assert_eq!(slots.len(), 4);
-        assert_eq!(slots.next(), Some(U256::from(1)));
-        assert_eq!(slots.len(), 3);
-        assert_eq!(slots.collect::<Vec<_>>(), vec![U256::from(2), U256::from(3), U256::from(4)]);
+        assert_eq!(
+            account.storage_slots().collect::<Vec<_>>(),
+            vec![U256::from(1), U256::from(2), U256::from(3), U256::from(4)]
+        );
     }
 }
 


### PR DESCRIPTION
## Motivation

Consumers such as paradigmxyz/reth#26955 need to iterate over both changed and read storage slots. Repeating the field-level chain leaks the `AccountChanges` representation.

## Solution

Adds `AccountChanges::storage_slots`, yielding changed slots followed by read slots as `U256` through a simple chained iterator. Coverage verifies the yielded order.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes